### PR TITLE
wideq: Implement AC

### DIFF
--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -79,6 +79,13 @@ class AirConditionerDevice(Device):
         self._status = AirConditionerStatus(self, res)
         return self._status
 
+    def set_state(self, key, value):
+        path = "/v1/service/devices/" + self._device_info.id + "/control-sync"
+        data = dict(ctrlKey="basicCtrl", command="Set", dataKey=key, dataValue=value)
+        #self._client.session.post2(path, json.dumps(data))
+        self._client.session.post2(path, data)
+        pass
+
 class AirConditionerStatus(DeviceStatus):
     """Higher-level information about a AC's current status.
 
@@ -129,8 +136,7 @@ class AirConditionerStatus(DeviceStatus):
 
     @property
     def is_on(self):
-        run_state = self._get_run_state()
-        return run_state != STATE_AC_OPERATION_OFF
+        return self.operation != STATE_AC_OPERATION_OFF
 
     @property
     def current_temp(self):
@@ -139,6 +145,11 @@ class AirConditionerStatus(DeviceStatus):
     @property
     def target_temp(self):
         return self._get_number_value(AC_STATE_TARGET_TEMP)
+
+    @target_temp.setter
+    def target_temp(self, temp):
+        # TODO check in range
+        return self._device.set_state(AC_STATE_TARGET_TEMP, temp)
 
     @property
     def current_humidity(self):
@@ -152,7 +163,28 @@ class AirConditionerStatus(DeviceStatus):
         strength = self.lookup_enum(AC_STATE_WIND_STRENGTH)
         return strength
 
+    @windstrength.setter
+    def windstrength(self, strength):
+        # TODO check support enum
+        return self._device.set_state(AC_STATE_WIND_STRENGTH, strength)
+
+    @property
+    def operation(self):
+        state = self.lookup_enum(AC_STATE_OPERATION)
+        return state
+
+    @operation.setter
+    def operation(self, op):
+        # TODO check support enum
+        return self._device.set_state(AC_STATE_OPERATION, op)
+
     @property
     def operation_mode(self):
         opmode = self.lookup_enum(AC_STATE_OPERATION_MODE)
         return opmode
+
+    @operation_mode.setter
+    def operation_mode(self, mode):
+        # TODO check suppert enum
+        return self._device.set_state(AC_STATE_OPERATION_MODE, mode)
+

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -39,6 +39,7 @@ AC_STATE_FILTER_REMAIN_TIME = "airState.filterMngStates.useTime"
 
 AC_STATE_WIND_UP_DOWN = "airState.wDir.upDown"
 AC_STATE_WIND_LEFT_RIGHT = "airState.wDir.leftRight"
+AC_STATE_WIND_VSTEP = "airState.wDir.vStep"
 
 class AirConditionerDevice(Device):
     """A higher-level interface for a AC."""
@@ -202,3 +203,13 @@ class AirConditionerStatus(DeviceStatus):
         except KeyError:
             return
         return self._device.set_state(AC_CTRL_WIND_DIRECTION, AC_STATE_WIND_LEFT_RIGHT, val)
+
+    @property
+    def wind_vstep(self):
+        # should check with another AC devices
+        return int(self._get_number_value(AC_STATE_WIND_VSTEP)) & 0xF
+
+    @wind_vstep.setter
+    def wind_vstep(self, step):
+        step &= 0xF
+        return self._device.set_state(AC_CTRL_WIND_DIRECTION, AC_STATE_WIND_VSTEP, step);

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -10,45 +10,6 @@ from .device import (
 )
 
 STATE_AC_OPERATION_OFF = "@AC_MAIN_OPERATION_OFF_W"
-STATE_AC_OPERATION_MODE = [
-    "@NON",
-    "@AC_MAIN_OPERATION_MODE_COOL_W",
-    "@AC_MAIN_OPERATION_MODE_DRY_W",
-    "@AC_MAIN_OPERATION_MODE_FAN_W",
-    "@AC_MAIN_OPERATION_MODE_AI_W",
-]
-
-STATE_AC_POWER_OFF = "@WM_STATE_POWER_OFF_W"
-STATE_AC_END = [
-    "@WM_STATE_END_W",
-    "@WM_STATE_COMPLETE_W",
-]
-STATE_AC_ERROR_OFF = "OFF"
-STATE_AC_ERROR_NO_ERROR = [
-    "ERROR_NOERROR",
-    "ERROR_NOERROR_TITLE",
-    "No Error",
-    "No_Error",
-]
-
-STATE_AC_WIND_STRENGTH = [
-    #"@AC_MAIN_WIND_STRENGTH_SLOW_W",
-    "@AC_MAIN_WIND_STRENGTH_SLOW_LOW_W",
-    "@AC_MAIN_WIND_STRENGTH_LOW_W",
-    #"@AC_MAIN_WIND_STRENGTH_LOW_MID_W",
-    "@AC_MAIN_WIND_STRENGTH_MID_W",
-    #"@AC_MAIN_WIND_STRENGTH_MID_HIGH_W",
-    "@AC_MAIN_WIND_STRENGTH_HIGH_W",
-    "@AC_MAIN_WIND_STRENGTH_POWER_W",
-    "@AC_MAIN_WIND_STRENGTH_AUTO_W",
-]
-
-STATE_AC_OPERATION_MODE = [
-    "@AC_MAIN_OPERATION_MODE_COOL_W",
-    "@AC_MAIN_OPERATION_MODE_DRY_W",
-    "@AC_MAIN_OPERATION_MODE_FAN_W",
-    "@AC_MAIN_OPERATION_MODE_AI_W",
-]
 
 SUPPORT_AC_OPERATION_MODE = "support.airState.opMode"
 SUPPORT_AC_WIND_STRENGTH = "support.airState.windStrength"
@@ -197,4 +158,3 @@ class AirConditionerStatus(DeviceStatus):
             return
         val = self._device.model_info.enum_value(AC_STATE_OPERATION_MODE, mode)
         return self._device.set_state(AC_STATE_OPERATION_MODE, val)
-

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -120,11 +120,11 @@ class AirConditionerStatus(DeviceStatus):
         return val / 10
 
     @property
-    def windstrength(self):
+    def wind_strength(self):
         return self.lookup_enum(AC_STATE_WIND_STRENGTH)
 
-    @windstrength.setter
-    def windstrength(self, strength):
+    @wind_strength.setter
+    def wind_strength(self, strength):
         try:
             self._device._model_info.enum_value(SUPPORT_AC_WIND_STRENGTH, op)
         except KeyError:

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -157,10 +157,10 @@ class AirConditionerStatus(DeviceStatus):
         val = self._device.model_info.enum_value(AC_STATE_OPERATION_MODE, mode)
         return self._device.set_state(AC_CTRL_BASIC, AC_STATE_OPERATION_MODE, val)
 
-    @property
-    def temp_unit(self):
-        unit = self.lookup_enum(AC_STATE_TEMP_UNIT)
-        return AC_TEMP_UNIT[unit]
+    #@property
+    #def temp_unit(self):
+    #    unit = self.lookup_enum(AC_STATE_TEMP_UNIT)
+    #    return AC_TEMP_UNIT[unit]
 
     @property
     def autodry_mode(self):

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -22,6 +22,7 @@ STATE_AC_OPERATION_OFF = "@AC_MAIN_OPERATION_OFF_W"
 AC_CTRL_BASIC = "basicCtrl"
 AC_CTRL_SETTING = "settingInfo"
 AC_CTRL_WIND_DIRECTION = "wDirCtrl"
+#AC_CTRL_WIND_MODE = "wModeCtrl"
 
 SUPPORT_AC_OPERATION_MODE = "support.airState.opMode"
 SUPPORT_AC_WIND_STRENGTH = "support.airState.windStrength"
@@ -34,12 +35,14 @@ AC_STATE_WIND_STRENGTH = "airState.windStrength"
 AC_STATE_TEMP_UNIT = "airState.tempState.unit"
 
 AC_STATE_AUTODRY_MODE = "airState.miscFuncState.autoDry"
+AC_STATE_AIRCLEAN_MODE= "airState.wMode.airClean"
 AC_STATE_FILTER_MAX_TIME = "airState.filterMngStates.maxTime"
 AC_STATE_FILTER_REMAIN_TIME = "airState.filterMngStates.useTime"
 
 AC_STATE_WIND_UP_DOWN = "airState.wDir.upDown"
 AC_STATE_WIND_LEFT_RIGHT = "airState.wDir.leftRight"
 AC_STATE_WIND_VSTEP = "airState.wDir.vStep"
+
 
 class AirConditionerDevice(Device):
     """A higher-level interface for a AC."""
@@ -171,6 +174,19 @@ class AirConditionerStatus(DeviceStatus):
         except KeyError:
             return
         return self._device.set_state(AC_CTRL_SETTING, AC_STATE_AUTODRY_MODE, val)
+
+    @property
+    def airclean_mode(self):
+        return self.lookup_enum(AC_STATE_AIRCLEAN_MODE) == AC_FLAG_ON
+
+    @airclean_mode.setter
+    def airclean_mode(self, use):
+        flag = AC_FLAG_ON if use else AC_FLAG_OFF
+        try:
+            val = self._device._model_info.enum_value(AC_STATE_AIRCLEAN_MODE, flag)
+        except KeyError:
+            return
+        return self._device.set_state(AC_CTRL_BASIC, AC_STATE_AIRCLEAN_MODE, val)
 
     @property
     def filter_remain(self):

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -1,0 +1,158 @@
+"""------------------for AC"""
+import logging
+from typing import Optional
+from numbers import Number
+
+from .device import (
+    Device,
+    DeviceStatus,
+    STATE_OPTIONITEM_NONE,
+    UNITTEMPMODES,
+)
+
+STATE_AC_OPERATION_OFF = "@AC_MAIN_OPERATION_OFF_W"
+STATE_AC_OPERATION_MODE = [
+    "@NON",
+    "@AC_MAIN_OPERATION_MODE_COOL_W",
+    "@AC_MAIN_OPERATION_MODE_DRY_W",
+    "@AC_MAIN_OPERATION_MODE_FAN_W",
+    "@AC_MAIN_OPERATION_MODE_AI_W",
+]
+
+STATE_AC_POWER_OFF = "@WM_STATE_POWER_OFF_W"
+STATE_AC_END = [
+    "@WM_STATE_END_W",
+    "@WM_STATE_COMPLETE_W",
+]
+STATE_AC_ERROR_OFF = "OFF"
+STATE_AC_ERROR_NO_ERROR = [
+    "ERROR_NOERROR",
+    "ERROR_NOERROR_TITLE",
+    "No Error",
+    "No_Error",
+]
+
+STATE_AC_WIND_STRENGTH = [
+    #"@AC_MAIN_WIND_STRENGTH_SLOW_W",
+    "@AC_MAIN_WIND_STRENGTH_SLOW_LOW_W",
+    "@AC_MAIN_WIND_STRENGTH_LOW_W",
+    #"@AC_MAIN_WIND_STRENGTH_LOW_MID_W",
+    "@AC_MAIN_WIND_STRENGTH_MID_W",
+    #"@AC_MAIN_WIND_STRENGTH_MID_HIGH_W",
+    "@AC_MAIN_WIND_STRENGTH_HIGH_W",
+    "@AC_MAIN_WIND_STRENGTH_POWER_W",
+    "@AC_MAIN_WIND_STRENGTH_AUTO_W",
+]
+
+STATE_AC_OPERATION_MODE = [
+    "@AC_MAIN_OPERATION_MODE_COOL_W",
+    "@AC_MAIN_OPERATION_MODE_DRY_W",
+    "@AC_MAIN_OPERATION_MODE_FAN_W",
+    "@AC_MAIN_OPERATION_MODE_AI_W",
+]
+
+#AC_CONTROL_COMMAND = "basicCtrl"
+AC_STATE_OPERATION = "airState.operation"
+AC_STATE_OPERATION_MODE = "airState.opMode"
+AC_STATE_CURRENT_TEMP = "airState.tempState.current"
+AC_STATE_TARGET_TEMP = "airState.tempState.target"
+AC_STATE_CURRENT_HUMIDITY = "airState.humidity.current"
+AC_STATE_WIND_STRENGTH = "airState.windStrength"
+
+class AirConditionerDevice(Device):
+    """A higher-level interface for a AC."""
+
+    def __init__(self, client, device):
+        super().__init__(client, device, AirConditionerStatus(self, None))
+
+    def reset_status(self):
+        self._status = AirConditionerStatus(self, None)
+        return self._status
+
+    def poll(self) -> Optional["AirConditionerStatus"]:
+        """Poll the device's current state."""
+
+        res = self.device_poll()
+        if not res:
+            return None
+
+        self._status = AirConditionerStatus(self, res)
+        return self._status
+
+class AirConditionerStatus(DeviceStatus):
+    """Higher-level information about a AC's current status.
+
+    :param device: The Device instance.
+    :param data: JSON data from the API.
+    """
+
+    def __init__(self, device, data):
+        super().__init__(device, data)
+        self._run_state = None
+        self._pre_state = None
+        self._error = None
+
+    def lookup_enum(self, key):
+        curr_key = self._get_data_key(key)
+        if not curr_key:
+            return None
+        return self._device.model_info.enum_name(
+            curr_key, self.int_or_none(self._data[curr_key])
+        )
+
+    def _get_run_state(self):
+        if not self._run_state:
+            state = self.lookup_enum(AC_STATE_OPERATION)
+            if not state:
+                self._run_state = STATE_WASHER_POWER_OFF
+            else:
+                self._run_state = state
+        return self._run_state
+
+    #def _get_error(self):
+    #    if not self._error:
+    #        error = self.lookup_reference(["Error", "error"], ref_key="title")
+    #        if not error:
+    #            self._error = STATE_WASHER_ERROR_OFF
+    #        else:
+    #            self._error = error
+    #    return self._error
+
+    def _get_number_value(self, key):
+        curr_key = self._get_data_key(key)
+        if not curr_key:
+            return None
+        value = self._data[curr_key]
+        if not isinstance(value, Number):
+            return None
+        return value
+
+    @property
+    def is_on(self):
+        run_state = self._get_run_state()
+        return run_state != STATE_AC_OPERATION_OFF
+
+    @property
+    def current_temp(self):
+        return self._get_number_value(AC_STATE_CURRENT_TEMP)
+
+    @property
+    def target_temp(self):
+        return self._get_number_value(AC_STATE_TARGET_TEMP)
+
+    @property
+    def current_humidity(self):
+        val = self._get_number_value(AC_STATE_CURRENT_HUMIDITY)
+        if not val:
+            return None
+        return val / 10
+
+    @property
+    def windstrength(self):
+        strength = self.lookup_enum(AC_STATE_WIND_STRENGTH)
+        return strength
+
+    @property
+    def operation_mode(self):
+        opmode = self.lookup_enum(AC_STATE_OPERATION_MODE)
+        return opmode

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -57,9 +57,6 @@ class AirConditionerStatus(DeviceStatus):
 
     def __init__(self, device, data):
         super().__init__(device, data)
-        self._run_state = None
-        self._pre_state = None
-        self._error = None
 
     def lookup_enum(self, key):
         curr_key = self._get_data_key(key)
@@ -68,24 +65,6 @@ class AirConditionerStatus(DeviceStatus):
         return self._device.model_info.enum_name(
             curr_key, self.int_or_none(self._data[curr_key])
         )
-
-    def _get_run_state(self):
-        if not self._run_state:
-            state = self.lookup_enum(AC_STATE_OPERATION)
-            if not state:
-                self._run_state = STATE_WASHER_POWER_OFF
-            else:
-                self._run_state = state
-        return self._run_state
-
-    #def _get_error(self):
-    #    if not self._error:
-    #        error = self.lookup_reference(["Error", "error"], ref_key="title")
-    #        if not error:
-    #            self._error = STATE_WASHER_ERROR_OFF
-    #        else:
-    #            self._error = error
-    #    return self._error
 
     def _get_number_value(self, key):
         curr_key = self._get_data_key(key)
@@ -123,8 +102,7 @@ class AirConditionerStatus(DeviceStatus):
 
     @property
     def windstrength(self):
-        strength = self.lookup_enum(AC_STATE_WIND_STRENGTH)
-        return strength
+        return self.lookup_enum(AC_STATE_WIND_STRENGTH)
 
     @windstrength.setter
     def windstrength(self, strength):
@@ -137,8 +115,7 @@ class AirConditionerStatus(DeviceStatus):
 
     @property
     def operation(self):
-        state = self.lookup_enum(AC_STATE_OPERATION)
-        return state
+        return self.lookup_enum(AC_STATE_OPERATION)
 
     @operation.setter
     def operation(self, op):
@@ -147,8 +124,7 @@ class AirConditionerStatus(DeviceStatus):
 
     @property
     def operation_mode(self):
-        opmode = self.lookup_enum(AC_STATE_OPERATION_MODE)
-        return opmode
+        return self.lookup_enum(AC_STATE_OPERATION_MODE)
 
     @operation_mode.setter
     def operation_mode(self, mode):

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -979,7 +979,7 @@ class ModelInfoControlDevice(ModelInfo):
             return EnumValue(d["value_mapping"])
         elif d["data_type"] in ("Range", "range"):
             return RangeValue(
-                d["value_mapping"]["min"], d["value_mapping"]["max"], d["value_mapping"]["step"]
+                d["value_validation"]["min"], d["value_validation"]["max"], d["value_validation"]["step"]
             )
         #elif d["type"] == "Bit":
         #    bit_values = {}

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -761,6 +761,8 @@ class Device(object):
                 self._model_info = ModelInfo(model_data)
             elif model_data.get("MonitoringValue"):
                 self._model_info = ModelInfoV2(model_data)
+            elif model_data.get('ControlDevice'):
+                self._model_info = ModelInfoControlDevice(model_data)
 
         if self._model_info is not None:
             # load model language pack
@@ -958,3 +960,44 @@ class DeviceStatus(object):
         if enum_val == LABEL_BIT_ON or enum_val == "INITIAL_BIT_ON":
             return STATE_OPTIONITEM_ON
         return STATE_OPTIONITEM_OFF
+
+
+class ModelInfoControlDevice(ModelInfo):
+    def value_type(self, name):
+        if name in self._data["Value"]:
+            return self._data["Value"][name]["data_type"]
+        else:
+            return None
+
+    def value(self, name):
+        """Look up information about a value.
+        
+        Return either an `EnumValue` or a `RangeValue`.
+        """
+        d = self._data["Value"][name]
+        if d["data_type"] in ("Enum", "enum"):
+            return EnumValue(d["value_mapping"])
+        elif d["data_type"] in ("Range", "range"):
+            return RangeValue(
+                d["value_mapping"]["min"], d["value_mapping"]["max"], d["value_mapping"]["step"]
+            )
+        #elif d["type"] == "Bit":
+        #    bit_values = {}
+        #    for bit in d["option"]:
+        #        bit_values[bit["startbit"]] = {
+        #            "value": bit["value"],
+        #            "length": bit["length"],
+        #        }
+        #    return BitValue(bit_values)
+        #elif d["type"] == "Reference":
+        #    ref = d["option"][0]
+        #    return ReferenceValue(self._data[ref])
+        #elif d["type"] == "Boolean":
+        #    return EnumValue({"0": "False", "1": "True"})
+        elif d["data_type"] == "String":
+            pass
+        else:
+            assert False, "unsupported value type {}".format(d["data_type"])
+
+    def decode_snapshot(self, data, key):
+        return data


### PR DESCRIPTION
I dont's make HA part yet(sorry I'm new of the ha)

this patch add to support AC control (related #37) and I'm only tested my system AC(model: `CST_570004_WW`)

properties:
- is_on: return the device on/off state
- current_temp
- target_temp
- current_humidity: a value seems `*10`
- wind_strength [= enum]: current strength & set new value, enum should be part of `SUPPORT_AC_WIND_STRENGTH`
- operation [= bool]: current state & turn on/off device
- operation_mode [= enum]: current wind type & set new value, enum should be part of `SUPPORT_AC_OPERATION_MODE`
- autodry_mode [= bool]: current mode & turn on/off mode
- airclean_mode [= bool]: current mode & turn on/off mode
- filter_remain: return the percent of the AC filter
- wind_up_down [= bool]: current state & turn on/off up/down wind mode
- wind_left_right [= bool]: current state & turn on/off left/right wind mode
- wind_vstep [= int]: current value & change up/down wind degrees, value should be 1-6

a control action uses @stefxx 's information of #47 & @brunostavares 's implementation.