### PR TITLE
Add LG Air Purifier Support

### DIFF
--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -262,3 +262,31 @@ class LGERangeDevice(LGEBaseDevice):
             unit = self._api.state.oven_temp_unit
             return TEMP_UNIT_LOOKUP.get(unit, TEMP_CELSIUS)
         return TEMP_CELSIUS
+
+
+class LGEAirPurifierDevice(LGEBaseDevice):
+    """A wrapper to monitor LGE air purifier devices"""
+
+    @property
+    def pm1(self):
+        if self._api.state:
+            return self._api.state.pm1
+        return None
+
+    @property
+    def pm25(self):
+        if self._api.state:
+            return self._api.state.pm25
+        return None
+
+    @property
+    def pm10(self):
+        if self._api.state:
+            return self._api.state.pm10
+        return None
+
+    @property
+    def filterRemainingLife(self):
+        if self._api.state:
+            return self._api.state.filterMngUseTime/self._api.state.filterMngMaxTime*100
+        return None

--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -89,6 +89,15 @@ REFRIGERATOR_SWITCH: Tuple[ThinQSwitchEntityDescription, ...] = (
         available_fn=lambda x: x.is_power_on and x.device.set_values_allowed,
     ),
 )
+AIRPURIFIER_SWITCH: Tuple[ThinQSwitchEntityDescription, ...] = (
+    ThinQSwitchEntityDescription(
+        key="power",
+        name="Power",
+        value_fn=lambda x: x.is_power_on,
+        turn_on_fn=lambda x: x.device.power(True),
+        turn_off_fn=lambda x: x.device.power(False),
+    ),
+)
 
 
 def _switch_exist(lge_device: LGEDevice, switch_desc: ThinQSwitchEntityDescription):
@@ -135,6 +144,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             LGESwitch(lge_device, switch_desc)
             for switch_desc in REFRIGERATOR_SWITCH
             for lge_device in lge_devices.get(DeviceType.REFRIGERATOR, [])
+            if _switch_exist(lge_device, switch_desc)
+        ]
+    )
+
+    # add air purifiers
+    lge_switch.extend(
+        [
+            LGESwitch(lge_device, switch_desc)
+            for switch_desc in AIRPURIFIER_SWITCH
+            for lge_device in lge_devices.get(DeviceType.AIR_PURIFIER, [])
             if _switch_exist(lge_device, switch_desc)
         ]
     )

--- a/custom_components/smartthinq_sensors/wideq/airpurifier.py
+++ b/custom_components/smartthinq_sensors/wideq/airpurifier.py
@@ -1,0 +1,129 @@
+"""------------------for Air Purifier"""
+import enum
+import logging
+
+from typing import Optional
+
+from .device import (
+    Device,
+    DeviceStatus,
+)
+
+AIRPURIFIER_CTRL_BASIC = ["Control", "basicCtrl"]
+
+AIRPURIFIER_STATE_OPERATION = ["Operation", "airState.operation"]
+AIRPURIFIER_STATE_PM1 = ["PM1", "airState.quality.PM1"]
+AIRPURIFIER_STATE_PM25 = ["PM25", "airState.quality.PM2"]
+AIRPURIFIER_STATE_PM10 = ["PM10", "airState.quality.PM10"]
+AIRPURIFIER_STATE_FILTERMNG_USE_TIME = [
+    "FilterMngMaxTime", "airState.filterMngStates.useTime"]
+AIRPURIFIER_STATE_FILTERMNG_MAX_TIME = [
+    "FilterMngMaxTime", "airState.filterMngStates.maxTime"]
+
+
+CMD_STATE_OPERATION = [AIRPURIFIER_CTRL_BASIC,
+                       "Set", AIRPURIFIER_STATE_OPERATION]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AirPufifierOp(enum.Enum):
+    """Whether a device is on or off."""
+
+    OFF = "@operation_off"
+    ON = "@operation_on"
+
+
+class AirPurifierDevice(Device):
+    """A higher-level interface for a Air Purifier."""
+
+    def __init__(self, client, device):
+        super().__init__(client, device, AirPurifierStatus(self, None))
+        self._supported_operation = None
+
+    def power(self, turn_on):
+        """Turn on or off the device (according to a boolean)."""
+
+        op = AirPufifierOp.ON if turn_on else AirPufifierOp.OFF
+        keys = self._get_cmd_keys(CMD_STATE_OPERATION)
+        op_value = self.model_info.enum_value(keys[2], op.value)
+        self.set(keys[0], keys[1], key=keys[2], value=op_value)
+
+    def set(self, ctrl_key, command, *, key=None, value=None, data=None):
+        """Set a device's control for `key` to `value`."""
+        super().set(ctrl_key, command, key=key, value=value, data=data)
+        if self._status:
+            self._status.update_status(key, value)
+
+    def reset_status(self):
+        self._status = AirPurifierStatus(self, None)
+        return self._status
+
+    def poll(self) -> Optional["AirPurifierStatus"]:
+        """Poll the device's current state."""
+
+        res = self.device_poll()
+        if not res:
+            return None
+
+        self._status = AirPurifierStatus(self, res)
+        return self._status
+
+
+class AirPurifierStatus(DeviceStatus):
+    """Higher-level information about a Air Pufifier's current status."""
+
+    def _get_state_key(self, key_name):
+        if isinstance(key_name, list):
+            return key_name[1 if self.is_info_v2 else 0]
+        return key_name
+
+    def _get_operation(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_OPERATION)
+        try:
+            return AirPufifierOp(self.lookup_enum(key, True))
+        except ValueError:
+            return None
+
+    @property
+    def is_on(self):
+        op = self._get_operation()
+        _LOGGER.debug(op)
+        if not op:
+            return False
+        return op != AirPufifierOp.OFF
+
+    @property
+    def operation(self):
+        op = self._get_operation()
+        if not op:
+            return None
+        return op.name
+
+    @property
+    def pm1(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_PM1)
+        return self._data.get(key)
+
+    @property
+    def pm25(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_PM25)
+        return self._data.get(key)
+
+    @property
+    def pm10(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_PM10)
+        return self._data.get(key)
+
+    @property
+    def filterMngUseTime(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_FILTERMNG_USE_TIME)
+        return self._data.get(key)
+
+    @property
+    def filterMngMaxTime(self):
+        key = self._get_state_key(AIRPURIFIER_STATE_FILTERMNG_MAX_TIME)
+        return self._data.get(key)
+
+    def _update_features(self):
+        result = []

--- a/custom_components/smartthinq_sensors/wideq/factory.py
+++ b/custom_components/smartthinq_sensors/wideq/factory.py
@@ -1,4 +1,5 @@
 
+from .airpurifier import AirPurifierDevice
 from .ac import AirConditionerDevice
 from .dishwasher import DishWasherDevice
 from .range import RangeDevice
@@ -40,5 +41,7 @@ def get_lge_device(client, device: DeviceInfo, temp_unit=UNIT_TEMP_CELSIUS):
         return StylerDevice(client, device)
     if device_type in WM_DEVICE_TYPES:
         return WMDevice(client, device)
+    if device_type == DeviceType.AIR_PURIFIER:
+        return AirPurifierDevice(client, device)
 
     return None


### PR DESCRIPTION
Tested on model id AIR_910604_WW
Currently support: Power, PM1, PM2.5, PM10, and Remaining Filter Life
![image](https://user-images.githubusercontent.com/35858349/134002933-a75a9a21-4329-48a0-8bba-5b7a848bffdd.png)
