### PR TITLE
Add support for getting air purifier's top filter life

### DIFF
--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -284,14 +284,3 @@ class LGEAirPurifierDevice(LGEBaseDevice):
         if self._api.state:
             return self._api.state.pm10
         return None
-
-    @property
-    def filter_remaining_life(self):
-        if self._api.state:
-            max_time = self._api.state.filter_mng_max_time
-            use_time = self._api.state.filter_mng_use_time
-            try:
-                return use_time/max_time*100
-            except ValueError:
-                return None
-        return None

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -14,6 +14,7 @@ from .wideq import (
     FEAT_HALFLOAD,
     FEAT_HOT_WATER_TEMP,
     FEAT_IN_WATER_TEMP,
+    FEAT_LOWER_FILTER_LIFE,
     FEAT_OUT_WATER_TEMP,
     FEAT_PRE_STATE,
     FEAT_PROCESS_STATE,
@@ -21,6 +22,7 @@ from .wideq import (
     FEAT_SPINSPEED,
     FEAT_TUBCLEAN_COUNT,
     FEAT_TEMPCONTROL,
+    FEAT_UPPER_FILTER_LIFE,
     FEAT_WATERTEMP,
     FEAT_COOKTOP_LEFT_FRONT_STATE,
     FEAT_COOKTOP_LEFT_REAR_STATE,
@@ -93,7 +95,6 @@ ATTR_OVEN_UPPER_TARGET_TEMP = "oven_upper_target_temp"
 ATTR_OVEN_TEMP_UNIT = "oven_temp_unit"
 
 # air purifier sensor attributes
-ATTR_FILTER_REMAINING_LIFE = "filter_remaining_life"
 ATTR_PM1 = "pm1"
 ATTR_PM10 = "pm10"
 ATTR_PM25 = "pm25"
@@ -369,11 +370,17 @@ AIR_PURIFIER_SENSORS: Tuple[ThinQSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     ),
     ThinQSensorEntityDescription(
-        key=ATTR_FILTER_REMAINING_LIFE,
-        name="Filter Remaining Life",
+        key=FEAT_LOWER_FILTER_LIFE,
+        name="Filter Remaining Life (Bottom)",
         icon="mdi:air-filter",
         state_class=STATE_CLASS_MEASUREMENT,
-        value_fn=lambda x: x.filter_remaining_life,
+        native_unit_of_measurement=PERCENTAGE,
+    ),
+    ThinQSensorEntityDescription(
+        key=FEAT_UPPER_FILTER_LIFE,
+        name="Filter Remaining Life (Top)",
+        icon="mdi:air-filter",
+        state_class=STATE_CLASS_MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
     ),
 )

--- a/custom_components/smartthinq_sensors/wideq/__init__.py
+++ b/custom_components/smartthinq_sensors/wideq/__init__.py
@@ -72,6 +72,9 @@ FEAT_OVEN_LOWER_STATE = "oven_lower_state"
 FEAT_OVEN_UPPER_CURRENT_TEMP = "oven_upper_current_temp"
 FEAT_OVEN_UPPER_STATE = "oven_upper_state"
 
+# air purifier device features
+FEAT_LOWER_FILTER_LIFE = "lower_filter_life"
+FEAT_UPPER_FILTER_LIFE = "upper_filter_life"
 
 # request ciphers settings
 CIPHERS = ":HIGH:!DH:!aNULL"

--- a/custom_components/smartthinq_sensors/wideq/airpurifier.py
+++ b/custom_components/smartthinq_sensors/wideq/airpurifier.py
@@ -147,6 +147,10 @@ class AirPurifierStatus(DeviceStatus):
 
     @property
     def upper_filter_life(self):
+        # Check the upper filter is exist
+        if self._device.model_info.enum_value(SUPPORT_AIR_PURIFIER_MFILTER[1], LABEL_UPPER_FILTER_SUPPORT) is None:
+            return None
+        
         feat_value = self._get_upper_filter_life()
         if feat_value is None:
             return None

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -1286,6 +1286,12 @@ class DeviceStatus(object):
             curr_key, value
         )
 
+    def lookup_range(self, key):
+        curr_key = self._get_data_key(key)
+        if not curr_key:
+            return None
+        return self._data[curr_key]
+
     def lookup_reference(self, key, ref_key="_comment"):
         curr_key = self._get_data_key(key)
         if not curr_key:


### PR DESCRIPTION
The community reported that some models have two filters, so I implemented it into the repo.
![244011257_924021984859279_3985432566047979537_n](https://user-images.githubusercontent.com/35858349/135652669-76a94d2f-d976-4280-9e7e-6365d36f221f.png)
![243476557_149366407337340_6591584959245992625_n](https://user-images.githubusercontent.com/35858349/135652682-f55998ec-4e10-4732-ad90-63d3573fe7aa.jpg)