### PR TITLE
Fix invalid accessing to None type data when device is lightwave oven

### DIFF
--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -815,7 +815,7 @@ class ModelInfo(object):
         protocol = self._data["Monitoring"]["protocol"]
         if isinstance(protocol, list):
             for elem in protocol:
-                if "superSet" in elem: 
+                if elem.get("superSet"):
                     key = elem["value"]
                     value = data
                     for ident in elem["superSet"].split("."):


### PR DESCRIPTION
If data value is `WiFiAccess`, `superSet` value is set `None`;
`{'_comment': 'WiFi Access Enable', 'superSet': None, 'value': 'WiFiAccess'}`

A condition of line 821 is just checking a key exists or not, so line will raise an error;
`Unexpected error fetching smartthinq_sensors-lightwave oven data: 'NoneType' object has no attribute 'split'`