### PR TITLE
AC: Adds switch to jet mode

### DIFF
--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -12,6 +12,7 @@ from .wideq import (
     FEAT_EXPRESSFRIDGE,
     FEAT_EXPRESSMODE,
     FEAT_ICEPLUS,
+    FEAT_MODE_JET,
     WM_DEVICE_TYPES,
     DeviceType,
 )
@@ -103,6 +104,16 @@ AC_DUCT_SWITCH = ThinQSwitchEntityDescription(
     name="Zone",
 )
 
+AC_MISC_SWITCH: Tuple[ThinQSwitchEntityDescription, ...] = (
+    ThinQSwitchEntityDescription(
+        key=FEAT_MODE_JET,
+        name="Jet mode",
+        icon="mdi:turbine",
+        turn_off_fn=lambda x: x.device.set_mode_jet(False),
+        turn_on_fn=lambda x: x.device.set_mode_jet(True),
+    ),
+)
+
 
 def _switch_exist(lge_device: LGEDevice, switch_desc: ThinQSwitchEntityDescription) -> bool:
     """Check if a switch exist for device."""
@@ -154,6 +165,16 @@ async def async_setup_entry(
             LGEDuctSwitch(lge_device, duct_zone)
             for lge_device in lge_devices.get(DeviceType.AC, [])
             for duct_zone in lge_device.device.duct_zones
+        ]
+    )
+
+    # add ac misc
+    lge_switch.extend(
+        [
+            LGESwitch(lge_device, switch_desc)
+            for switch_desc in AC_MISC_SWITCH
+            for lge_device in lge_devices.get(DeviceType.AC, [])
+            if _switch_exist(lge_device, switch_desc)
         ]
     )
 

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -908,7 +908,7 @@ class AirConditionerStatus(DeviceStatus):
         key = self._get_state_key(STATE_MODE_JET)
         if (value := self.to_int_or_none(self._data.get(key))) is None:
             return None
-        status = value in (self.to_int_or_none(MODE_JET_COOL), self.to_int_or_none(MODE_JET_HEAT))
+        status = str(value) in (MODE_JET_COOL, MODE_JET_HEAT)
         return self._update_feature(FEAT_MODE_JET, status, False)
 
     def _update_features(self):

--- a/custom_components/smartthinq_sensors/wideq/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/ac.py
@@ -664,7 +664,7 @@ class AirConditionerDevice(Device):
             elif self._status.operation_mode in (ACMode.COOL.name, ACMode.DRY.name):
                 jet = MODE_JET_COOL
             else:
-                return False
+                raise ValueError("Invalid device status for jet mode")
         else:
             jet = MODE_JET_OFF
         await self.set(keys[0], keys[1], key=keys[2], value=jet)
@@ -906,13 +906,10 @@ class AirConditionerStatus(DeviceStatus):
     @property
     def mode_jet(self):
         key = self._get_state_key(STATE_MODE_JET)
-        if self._data.get(key) == self.to_int_or_none(MODE_JET_COOL) or self._data.get(
-            key
-        ) == self.to_int_or_none(MODE_JET_HEAT):
-            value = True
-        else:
-            value = False
-        return self._update_feature(FEAT_MODE_JET, value, False)
+        if (value := self.to_int_or_none(self._data.get(key))) is None:
+            return None
+        status = value in (self.to_int_or_none(MODE_JET_COOL), self.to_int_or_none(MODE_JET_HEAT))
+        return self._update_feature(FEAT_MODE_JET, status, False)
 
     def _update_features(self):
         _ = [

--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -21,6 +21,7 @@ FEAT_HUMIDITY = "humidity"
 FEAT_HOT_WATER_TEMP = "hot_water_temperature"
 FEAT_IN_WATER_TEMP = "in_water_temperature"
 FEAT_OUT_WATER_TEMP = "out_water_temperature"
+FEAT_MODE_JET = "mode_jet"
 
 # wash devices features
 FEAT_DRYLEVEL = "dry_level"


### PR DESCRIPTION
Adds the swtich to toggle jet mode on and off (#175).

Manual information and application behavior observation: Jet mode is compatible with HVAC COOL, HEAT and DRY modes (by my tests when activating in dry mode, cool mode is selected automatically).

Here's an explanation of the jet mode according to [the manual](https://www.lg.com/au/support/products/documents/S24AWN.pdf), but it may have some variation depending on the model:
![image](https://user-images.githubusercontent.com/31328123/182999065-ea97f756-03b3-48d3-ac96-d50c6e33a7dd.png)
