### PR TITLE
Simplify state lookup

### DIFF
--- a/custom_components/smartthinq_sensors/binary_sensor.py
+++ b/custom_components/smartthinq_sensors/binary_sensor.py
@@ -343,18 +343,12 @@ class LGEBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Return True if unable to access real state of the entity."""
         return self._api.assumed_state
 
-    def _get_on_state(self):
+    def _get_on_state(self) -> bool:
         """Return true if the binary sensor is on."""
-        ret_val = self._get_sensor_state()
-        if ret_val is None:
-            return False
-        if isinstance(ret_val, bool):
-            return ret_val
-        ret_val = ret_val.lower()
-        if ret_val == STATE_ON:
-            return True
-        state = STATE_LOOKUP.get(ret_val, STATE_OFF)
-        return state == STATE_ON
+        sensor_state = self._get_sensor_state()
+        if isinstance(sensor_state, bool):
+            return sensor_state
+        return sensor_state.lower() in (STATE_ON, 'on')
 
     def _get_sensor_state(self):
         if self._wrap_device and self.entity_description.value_fn is not None:


### PR DESCRIPTION
This implementation avoids the use of a lookup table and instead uses the in operator to check if the sensor state is equal to STATE_ON or the string "on". It also removes the branch for handling the case where sensor_state is None, since the in operator will return False in that case.