### PR TITLE
Add start and end time attributes

### DIFF
--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -140,28 +140,22 @@ class LGEWashDevice(LGEBaseDevice):
     @property
     def start_time(self):
         """Return the time and date the wash began or will begin in ISO format."""
-        if self._api.state:
-            if self._api.state.is_on:
-                state = self._api.state
-                start = datetime.now() + timedelta(
-                    hours=state.reservetime_hour - state.initialtime_hour + state.remaintime_hour,
-                    minutes=state.reservetime_min - state.initialtime_min + state.remaintime_min
-                )
-                return start.isoformat()
-        return ""
+        if not (self._api.state and self._api.state.is_on):
+            return ""
+        state = self._api.state
+        hrs = state.reservetime_hour - state.initialtime_hour + state.remaintime_hour
+        mins = state.reservetime_min - state.initialtime_min + state.remaintime_min
+        return (datetime.now() + timedelta(hours=hrs, minutes=mins)).isoformat()
 
     @property
     def end_time(self):
         """Return the time and date the wash will end in ISO format."""
-        if self._api.state:
-            if self._api.state.is_on:
-                state = self._api.state
-                start = datetime.now() + timedelta(
-                    hours=state.reservetime_hour + state.remaintime_hour,
-                    minutes=state.reservetime_min + state.remaintime_min
-                )
-                return start.isoformat()
-        return ""
+        if not (self._api.state and self._api.state.is_on):
+            return ""
+        state = self._api.state
+        hrs = state.reservetime_hour + state.remaintime_hour
+        mins = state.reservetime_min + state.remaintime_min
+        return (datetime.now() + timedelta(hours=hrs, minutes=mins)).isoformat()
 
     @property
     def initial_time(self):

--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -1,5 +1,7 @@
 """Helper class for ThinQ devices"""
 
+from datetime import datetime, timedelta
+
 from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
 
 from .const import DEFAULT_SENSOR
@@ -134,6 +136,18 @@ class LGEWashDevice(LGEBaseDevice):
             if self._api.state.is_error:
                 return STATE_ON
         return STATE_OFF
+
+    @property
+    def start_time(self):
+        """Return the time and date the wash began or will begin in ISO format."""
+        if self._api.state:
+            if self._api.state.is_on:
+                start = datetime.now() + timedelta(
+                    hours=self._api.state.reservetime_hour - self._api.state.remaintime_hour,
+                    minutes=self._api.state.reservetime_min - self._api.state.remaintime_min
+                )
+                return start.isoformat()
+        return ""
 
     @property
     def initial_time(self):

--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -142,9 +142,23 @@ class LGEWashDevice(LGEBaseDevice):
         """Return the time and date the wash began or will begin in ISO format."""
         if self._api.state:
             if self._api.state.is_on:
+                state = self._api.state
                 start = datetime.now() + timedelta(
-                    hours=self._api.state.reservetime_hour - self._api.state.remaintime_hour,
-                    minutes=self._api.state.reservetime_min - self._api.state.remaintime_min
+                    hours=state.reservetime_hour - state.initialtime_hour + state.remaintime_hour,
+                    minutes=state.reservetime_min - state.initialtime_min + state.remaintime_min
+                )
+                return start.isoformat()
+        return ""
+
+    @property
+    def end_time(self):
+        """Return the time and date the wash will end in ISO format."""
+        if self._api.state:
+            if self._api.state.is_on:
+                state = self._api.state
+                start = datetime.now() + timedelta(
+                    hours=state.reservetime_hour + state.remaintime_hour,
+                    minutes=state.reservetime_min + state.remaintime_min
                 )
                 return start.isoformat()
         return ""

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -58,6 +58,7 @@ ATTR_ERROR_STATE = "error_state"
 ATTR_INITIAL_TIME = "initial_time"
 ATTR_REMAIN_TIME = "remain_time"
 ATTR_RESERVE_TIME = "reserve_time"
+ATTR_START_TIME = "remain_time"
 ATTR_RUN_COMPLETED = "run_completed"
 
 # refrigerator sensor attributes
@@ -716,6 +717,7 @@ class LGEWashDeviceSensor(LGESensor):
         data = {
             ATTR_RUN_COMPLETED: self._wrap_device.run_completed,
             ATTR_ERROR_STATE: self._wrap_device.error_state,
+            ATTR_START_TIME: self._wrap_device.start_time,
             ATTR_INITIAL_TIME: self._wrap_device.initial_time,
             ATTR_REMAIN_TIME: self._wrap_device.remain_time,
             ATTR_RESERVE_TIME: self._wrap_device.reserve_time,

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -58,7 +58,8 @@ ATTR_ERROR_STATE = "error_state"
 ATTR_INITIAL_TIME = "initial_time"
 ATTR_REMAIN_TIME = "remain_time"
 ATTR_RESERVE_TIME = "reserve_time"
-ATTR_START_TIME = "remain_time"
+ATTR_START_TIME = "start_time"
+ATTR_END_TIME = "end_time"
 ATTR_RUN_COMPLETED = "run_completed"
 
 # refrigerator sensor attributes
@@ -718,6 +719,7 @@ class LGEWashDeviceSensor(LGESensor):
             ATTR_RUN_COMPLETED: self._wrap_device.run_completed,
             ATTR_ERROR_STATE: self._wrap_device.error_state,
             ATTR_START_TIME: self._wrap_device.start_time,
+            ATTR_END_TIME: self._wrap_device.end_time,
             ATTR_INITIAL_TIME: self._wrap_device.initial_time,
             ATTR_REMAIN_TIME: self._wrap_device.remain_time,
             ATTR_RESERVE_TIME: self._wrap_device.reserve_time,


### PR DESCRIPTION
The PR adds `start_time` and `end_time` attributes to washing machines, which indicates what time of day the washer started running & what time it will end.
It is similar to the same attributes used in the [OpenSprinler custom integration](https://github.com/vinteo/hass-opensprinkler).

This attribute is helpful for the [Timer Bar Card](github.com/rianadon/timer-bar-card) (disclosure: my own card), which uses the start time to display the time the washer is scheduled to run. The card prefers using timestamps rather than a hh:mm offset because the hh:mm format requires the entity to update its state every minute to give a new hh:mm estimate, whereas the start time timestamp will change much less often.

I don't have an LG washer so have not been able to test whether the code is bug free or whether taking the `current time + reserve time - initial time + remaining time` is the correct way to calculate the start time.

See also: https://github.com/rianadon/timer-bar-card/issues/70