### PR TITLE
Add Range sensors and improve existing (FR #454)

### DIFF
--- a/custom_components/smartthinq_sensors/binary_sensor.py
+++ b/custom_components/smartthinq_sensors/binary_sensor.py
@@ -166,14 +166,15 @@ RANGE_BINARY_SENSORS: Tuple[ThinQBinarySensorEntityDescription, ...] = (
     ThinQBinarySensorEntityDescription(
         key=ATTR_COOKTOP_STATE,
         name="Cooktop state",
-        device_class=BinarySensorDeviceClass.HEAT,
+        device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda x: x.cooktop_state,
     ),
     ThinQBinarySensorEntityDescription(
         key=ATTR_OVEN_STATE,
         name="Oven state",
-        device_class=BinarySensorDeviceClass.HEAT,
+        device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda x: x.oven_state,
+        entity_registry_enabled_default=False,
     ),
 )
 DEHUMIDIFIER_BINARY_SENSORS: Tuple[ThinQBinarySensorEntityDescription, ...] = (

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -302,8 +302,18 @@ RANGE_SENSORS: Tuple[ThinQSensorEntityDescription, ...] = (
         icon="mdi:inbox-arrow-down",
     ),
     ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_LOWER_MODE,
+        name="Oven lower mode",
+        icon="mdi:inbox-arrow-down",
+    ),
+    ThinQSensorEntityDescription(
         key=RangeFeatures.OVEN_UPPER_STATE,
         name="Oven upper state",
+        icon="mdi:inbox-arrow-up",
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_UPPER_MODE,
+        name="Oven upper mode",
         icon="mdi:inbox-arrow-up",
     ),
     ThinQSensorEntityDescription(
@@ -762,6 +772,20 @@ class LGERangeSensor(LGESensor):
     ):
         """Initialize the sensor."""
         super().__init__(api, description, LGERangeDevice(api))
+
+    @property
+    def native_value(self) -> float | int | str | None:
+        """Return the state of the sensor."""
+        value = super().native_value
+        dev_class = self.entity_description.device_class
+        if dev_class and dev_class == SensorDeviceClass.TEMPERATURE:
+            try:
+                num_val = int(value)
+            except (TypeError, ValueError):
+                return value
+            if num_val == 0:
+                return None
+        return value
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -87,8 +87,10 @@ class RangeFeatures(StrEnum):
     COOKTOP_RIGHT_FRONT_STATE = "cooktop_right_front_state"
     COOKTOP_RIGHT_REAR_STATE = "cooktop_right_rear_state"
     OVEN_LOWER_CURRENT_TEMP = "oven_lower_current_temp"
+    OVEN_LOWER_MODE = "oven_lower_mode"
     OVEN_LOWER_STATE = "oven_lower_state"
     OVEN_UPPER_CURRENT_TEMP = "oven_upper_current_temp"
+    OVEN_UPPER_MODE = "oven_upper_mode"
     OVEN_UPPER_STATE = "oven_upper_state"
 
 

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -35,6 +35,7 @@ LOCAL_LANG_PACK = {
     "INITIAL_BIT_OFF": StateOptions.OFF,
     "INITIAL_BIT_ON": StateOptions.ON,
     "IGNORE": StateOptions.NONE,
+    "NONE": StateOptions.NONE,
     "NOT_USE": "Not Used",
 }
 

--- a/custom_components/smartthinq_sensors/wideq/devices/range.py
+++ b/custom_components/smartthinq_sensors/wideq/devices/range.py
@@ -75,14 +75,14 @@ class RangeStatus(DeviceStatus):
     @property
     def is_cooktop_on(self):
         """Return if cooktop is on."""
-        result = [
-            self.cooktop_left_front_state,
-            self.cooktop_left_rear_state,
-            self.cooktop_center_state,
-            self.cooktop_right_front_state,
-            self.cooktop_right_rear_state,
-        ]
-        for res in result:
+        for feature in [
+            RangeFeatures.COOKTOP_CENTER_STATE,
+            RangeFeatures.COOKTOP_LEFT_FRONT_STATE,
+            RangeFeatures.COOKTOP_LEFT_REAR_STATE,
+            RangeFeatures.COOKTOP_RIGHT_FRONT_STATE,
+            RangeFeatures.COOKTOP_RIGHT_REAR_STATE,
+        ]:
+            res = self.device_features.get(feature)
             if res and res != StateOptions.OFF:
                 return True
         return False
@@ -94,7 +94,9 @@ class RangeStatus(DeviceStatus):
         # the five burners do not report individual status.
         # Instead, the cooktop_left_front reports aggregated status for all burners.
         status = self.lookup_enum("LFState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.COOKTOP_LEFT_FRONT_STATE, status)
 
@@ -102,7 +104,9 @@ class RangeStatus(DeviceStatus):
     def cooktop_left_rear_state(self):
         """Return left rear cooktop state."""
         status = self.lookup_enum("LRState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.COOKTOP_LEFT_REAR_STATE, status)
 
@@ -110,7 +114,9 @@ class RangeStatus(DeviceStatus):
     def cooktop_center_state(self):
         """Return center cooktop state."""
         status = self.lookup_enum("CenterState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.COOKTOP_CENTER_STATE, status)
 
@@ -118,7 +124,9 @@ class RangeStatus(DeviceStatus):
     def cooktop_right_front_state(self):
         """Return right front cooktop state."""
         status = self.lookup_enum("RFState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.COOKTOP_RIGHT_FRONT_STATE, status)
 
@@ -126,18 +134,20 @@ class RangeStatus(DeviceStatus):
     def cooktop_right_rear_state(self):
         """Return right rear cooktop state."""
         status = self.lookup_enum("RRState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.COOKTOP_RIGHT_REAR_STATE, status)
 
     @property
     def is_oven_on(self):
         """Return if oven is on."""
-        result = [
-            self.oven_lower_state,
-            self.oven_upper_state,
-        ]
-        for res in result:
+        for feature in [
+            RangeFeatures.OVEN_LOWER_STATE,
+            RangeFeatures.OVEN_UPPER_STATE,
+        ]:
+            res = self.device_features.get(feature)
             if res and res != StateOptions.OFF:
                 return True
         return False
@@ -146,17 +156,37 @@ class RangeStatus(DeviceStatus):
     def oven_lower_state(self):
         """Return oven lower state."""
         status = self.lookup_enum("LowerOvenState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.OVEN_LOWER_STATE, status)
+
+    @property
+    def oven_lower_mode(self):
+        """Return oven lower mode."""
+        status = self.lookup_enum("LowerCookMode")
+        if status is None:
+            return None
+        return self._update_feature(RangeFeatures.OVEN_LOWER_MODE, status)
 
     @property
     def oven_upper_state(self):
         """Return oven upper state."""
         status = self.lookup_enum("UpperOvenState")
-        if status and status == ITEM_STATE_OFF:
+        if status is None:
+            return None
+        if status == ITEM_STATE_OFF:
             status = BIT_OFF
         return self._update_feature(RangeFeatures.OVEN_UPPER_STATE, status)
+
+    @property
+    def oven_upper_mode(self):
+        """Return oven upper mode."""
+        status = self.lookup_enum("UpperCookMode")
+        if status is None:
+            return None
+        return self._update_feature(RangeFeatures.OVEN_UPPER_MODE, status)
 
     @property
     def oven_lower_target_temp(self):
@@ -220,7 +250,9 @@ class RangeStatus(DeviceStatus):
             self.cooktop_right_front_state,
             self.cooktop_right_rear_state,
             self.oven_lower_state,
+            self.oven_lower_mode,
             self.oven_lower_current_temp,
             self.oven_upper_state,
+            self.oven_upper_mode,
             self.oven_upper_current_temp,
         ]


### PR DESCRIPTION
- Add Oven mode sensors
- Avoid return not existing sensors
- Return unknown status for temperatures when zero
- Improve Oven and CookTop status detection
- Change device class to POWER for binary sensors