### PR TITLE
Increase default http timeout to 15 seconds

### DIFF
--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -5,7 +5,7 @@ from .core_enum import StrEnum
 # default core settings
 DEFAULT_COUNTRY = "US"
 DEFAULT_LANGUAGE = "en-US"
-DEFAULT_TIMEOUT = 10  # seconds
+DEFAULT_TIMEOUT = 15  # seconds
 
 # bit status
 BIT_OFF = "OFF"

--- a/custom_components/smartthinq_sensors/wideq/core_async.py
+++ b/custom_components/smartthinq_sensors/wideq/core_async.py
@@ -150,13 +150,13 @@ class CoreAsync:
         Parameters:
             country: ThinQ account country
             language: ThinQ account language
-            timeout: the http timeout (default = 10 sec.)
+            timeout: the http timeout (default = 15 sec.)
             session: the AioHttp session to use (if None a new session is created)
         """
 
         self._country = country
         self._language = language
-        self._timeout = timeout
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
         self._oauth_url = oauth_url
 
         if session:
@@ -263,6 +263,7 @@ class CoreAsync:
         """Make a generic HTTP request."""
         async with self._get_session().get(
             url=url,
+            timeout=self._timeout,
         ) as resp:
             result = await resp.content.read()
 


### PR DESCRIPTION
- Increase default http timeout to 15 seconds to avoid startup issue
- Initialize timeout to ClientTimeout object
- Add timeout for generic http requests