### PR TITLE
Add Remote Start button for Washer Devices

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -61,6 +61,7 @@ from .wideq.device import Device as ThinQDevice
 
 SMARTTHINQ_PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.FAN,
     Platform.HUMIDIFIER,

--- a/custom_components/smartthinq_sensors/button.py
+++ b/custom_components/smartthinq_sensors/button.py
@@ -1,0 +1,133 @@
+"""Support for ThinQ device buttons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Awaitable, Callable, Tuple
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import LGEDevice
+from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import LGEBaseDevice, get_entity_name, get_multiple_devices_types
+from .wideq import WM_DEVICE_TYPES
+
+# general button attributes
+ATTR_REMOTE_START = "remote_start"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ThinQButtonDescriptionMixin:
+    """Mixin to describe a Button entity."""
+
+    press_action_fn: Callable[[Any], Awaitable[None]]
+
+
+@dataclass
+class ThinQButtonEntityDescription(
+    ButtonEntityDescription, ThinQButtonDescriptionMixin
+):
+    """A class that describes ThinQ button entities."""
+
+    available_fn: Callable[[Any], bool] | None = None
+
+
+WASH_DEV_BUTTON: Tuple[ThinQButtonEntityDescription, ...] = (
+    ThinQButtonEntityDescription(
+        key=ATTR_REMOTE_START,
+        name="Remote Start",
+        device_class=ButtonDeviceClass.UPDATE,
+        press_action_fn=lambda x: x.device.remote_start(),
+        available_fn=lambda x: x.device.remote_start_enabled,
+    ),
+)
+
+
+def _button_exist(
+    lge_device: LGEDevice, button_desc: ThinQButtonEntityDescription
+) -> bool:
+    """Check if a button exist for device."""
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the LGE buttons."""
+    entry_config = hass.data[DOMAIN]
+    lge_cfg_devices = entry_config.get(LGE_DEVICES)
+
+    _LOGGER.debug("Starting LGE ThinQ button setup...")
+
+    @callback
+    def _async_discover_device(lge_devices: dict) -> None:
+        """Add entities for a discovered ThinQ device."""
+
+        if not lge_devices:
+            return
+
+        lge_button = []
+
+        # add WM devices
+        lge_button.extend(
+            [
+                LGEButton(lge_device, button_desc)
+                for button_desc in WASH_DEV_BUTTON
+                for lge_device in get_multiple_devices_types(
+                    lge_devices, WM_DEVICE_TYPES
+                )
+                if _button_exist(lge_device, button_desc)
+            ]
+        )
+
+        async_add_entities(lge_button)
+
+    _async_discover_device(lge_cfg_devices)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, LGE_DISCOVERY_NEW, _async_discover_device)
+    )
+
+
+class LGEButton(CoordinatorEntity, ButtonEntity):
+    """Class to control buttons for LGE device"""
+
+    entity_description: ThinQButtonEntityDescription
+
+    def __init__(
+        self,
+        api: LGEDevice,
+        description: ThinQButtonEntityDescription,
+    ):
+        """Initialize the button."""
+        super().__init__(api.coordinator)
+        self._api = api
+        self._wrap_device = LGEBaseDevice(api)
+        self.entity_description = description
+        self._attr_name = get_entity_name(api, description.key, description.name)
+        self._attr_unique_id = f"{api.unique_id}-{description.key}-button"
+        self._attr_device_info = api.device_info
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        is_avail = True
+        if self.entity_description.available_fn is not None:
+            is_avail = self.entity_description.available_fn(self._wrap_device)
+        return self._api.available and is_avail
+
+    async def async_press(self) -> None:
+        """Triggers service."""
+        await self.entity_description.press_action_fn(self._wrap_device)

--- a/custom_components/smartthinq_sensors/button.py
+++ b/custom_components/smartthinq_sensors/button.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
 from .device_helpers import LGEBaseDevice, get_entity_name, get_multiple_devices_types
-from .wideq import WM_DEVICE_TYPES
+from .wideq import WM_DEVICE_TYPES, WashDeviceFeatures
 
 # general button attributes
 ATTR_REMOTE_START = "remote_start"
@@ -42,6 +42,7 @@ class ThinQButtonEntityDescription(
     """A class that describes ThinQ button entities."""
 
     available_fn: Callable[[Any], bool] | None = None
+    related_feature: str | None = None
 
 
 WASH_DEV_BUTTON: Tuple[ThinQButtonEntityDescription, ...] = (
@@ -51,6 +52,7 @@ WASH_DEV_BUTTON: Tuple[ThinQButtonEntityDescription, ...] = (
         device_class=ButtonDeviceClass.UPDATE,
         press_action_fn=lambda x: x.device.remote_start(),
         available_fn=lambda x: x.device.remote_start_enabled,
+        related_feature=WashDeviceFeatures.REMOTESTART,
     ),
 )
 
@@ -59,7 +61,11 @@ def _button_exist(
     lge_device: LGEDevice, button_desc: ThinQButtonEntityDescription
 ) -> bool:
     """Check if a button exist for device."""
-    return True
+    feature = button_desc.related_feature
+    if feature is None or feature in lge_device.available_features:
+        return True
+
+    return False
 
 
 async def async_setup_entry(

--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -34,7 +34,7 @@ from .wideq import (
 )
 
 # general sensor attributes
-ATTR_POWER_OFF = "power_off"
+ATTR_POWER = "power"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,10 +51,11 @@ class ThinQSwitchEntityDescription(SwitchEntityDescription):
 
 WASH_DEV_SWITCH: Tuple[ThinQSwitchEntityDescription, ...] = (
     ThinQSwitchEntityDescription(
-        key=ATTR_POWER_OFF,
-        name="Power off",
-        value_fn=lambda x: x.is_power_on,
+        key=ATTR_POWER,
+        name="Power",
+        value_fn=lambda x: x.is_power_on and not x.device.stand_by,
         turn_off_fn=lambda x: x.device.power_off(),
+        turn_on_fn=lambda x: x.device.wake_up(),
         available_fn=lambda x: x.is_power_on,
     ),
 )

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -82,6 +82,7 @@ class Monitor:
     ) -> None:
         """Log and raise error with different level depending on condition."""
         log_lev = logging.DEBUG
+        self._disconnected = True
         if not_logged and Monitor._client_connected:
             Monitor._client_connected = False
             self._has_error = True

--- a/custom_components/smartthinq_sensors/wideq/devices/washerDryer.py
+++ b/custom_components/smartthinq_sensors/wideq/devices/washerDryer.py
@@ -289,9 +289,10 @@ class WMDevice(Device):
     def _set_remote_start_opt(self, res):
         """Save the status to use for remote start."""
         self._stand_by = (
-            self._status.device_features[WashDeviceFeatures.STANDBY] == StateOptions.ON
+            self._status.device_features.get(WashDeviceFeatures.STANDBY)
+            == StateOptions.ON
         )
-        remote_start = self._status.device_features[WashDeviceFeatures.REMOTESTART]
+        remote_start = self._status.device_features.get(WashDeviceFeatures.REMOTESTART)
         if remote_start == StateOptions.ON:
             if self._remote_start_status is None:
                 self._remote_start_status = res


### PR DESCRIPTION
- Add Remote Start button (tested on ThinqV1 devices)
- Change Power Off switch to Power switch (breaking change)
- Use Power switch to wake-up device from stand-by (tested on ThinqV1 devices)
- Fix issue on ThinqV1 devices that could cause loss of connection