### PR TITLE
feat: implements mode UV nano for air conditioner RAC_056905_WW

### DIFF
--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -114,6 +114,13 @@ AC_SWITCH: Tuple[ThinQSwitchEntityDescription, ...] = (
         turn_on_fn=lambda x: x.device.set_lighting_display(True),
     ),
     ThinQSwitchEntityDescription(
+        key=AirConditionerFeatures.MODE_UN_NANO,
+        name="UV Nano",
+        icon="mdi:alpha-u-box-outline",
+        turn_off_fn=lambda x: x.device.set_uv_nano(False),
+        turn_on_fn=lambda x: x.device.set_uv_nano(True),
+    ),
+    ThinQSwitchEntityDescription(
         key=AirConditionerFeatures.MODE_AWHP_SILENT,
         name="Silent mode",
         icon="mdi:ear-hearing-off",

--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -45,6 +45,7 @@ class AirConditionerFeatures(StrEnum):
     ROOM_TEMP = "room_temperature"
     WATER_IN_TEMP = "water_in_temperature"
     WATER_OUT_TEMP = "water_out_temperature"
+    MODE_UN_NANO = "mode_un_nano"
 
 
 class AirPurifierFeatures(StrEnum):

--- a/custom_components/smartthinq_sensors/wideq/devices/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/devices/ac.py
@@ -62,6 +62,7 @@ STATE_HUMIDITY = ["SensorHumidity", "airState.humidity.current"]
 STATE_MODE_AIRCLEAN = ["AirClean", "airState.wMode.airClean"]
 STATE_MODE_JET = ["Jet", "airState.wMode.jet"]
 STATE_LIGHTING_DISPLAY = ["DisplayControl", "airState.lightingState.displayControl"]
+STATE_UV_NANO = ["UVNano", "airState.miscFuncState.Uvnano"]
 STATE_RESERVATION_SLEEP_TIME = ["SleepTime", "airState.reservation.sleepTime"]
 
 FILTER_TYPES = [
@@ -89,6 +90,7 @@ CMD_STATE_DUCT_ZONES = [CTRL_MISC, "Set", [DUCT_ZONE_V1, "airState.ductZone.cont
 CMD_STATE_MODE_AIRCLEAN = [CTRL_BASIC, "Set", STATE_MODE_AIRCLEAN]
 CMD_STATE_MODE_JET = [CTRL_BASIC, "Set", STATE_MODE_JET]
 CMD_STATE_LIGHTING_DISPLAY = [CTRL_BASIC, "Set", STATE_LIGHTING_DISPLAY]
+CMD_STATE_UV_NANO = [CTRL_BASIC, "Set", STATE_UV_NANO]
 CMD_RESERVATION_SLEEP_TIME = [CTRL_BASIC, "Set", STATE_RESERVATION_SLEEP_TIME]
 
 # AWHP Section
@@ -126,6 +128,9 @@ ADD_FEAT_POLL_INTERVAL = 300  # 5 minutes
 
 LIGHTING_DISPLAY_OFF = "0"
 LIGHTING_DISPLAY_ON = "1"
+
+UV_NANO_OFF = "0"
+UV_NANO_ON = "1"
 
 MODE_OFF = "@OFF"
 MODE_ON = "@ON"
@@ -805,6 +810,12 @@ class AirConditionerDevice(Device):
         lighting = LIGHTING_DISPLAY_ON if status else LIGHTING_DISPLAY_OFF
         await self.set(keys[0], keys[1], key=keys[2], value=lighting)
 
+    async def set_uv_nano(self, status: bool):
+        """Set the lighting display on or off."""
+        keys = self._get_cmd_keys(CMD_STATE_UV_NANO)
+        state = UV_NANO_ON if status else UV_NANO_OFF
+        await self.set(keys[0], keys[1], key=keys[2], value=state)
+
     async def set_mode_awhp_silent(self, value: bool):
         """Set the AWHP silent mode on or off."""
         if not self.is_air_to_water:
@@ -1220,6 +1231,18 @@ class AirConditionerStatus(DeviceStatus):
         )
 
     @property
+    def mode_uv_nano(self):
+        """Return display lighting status."""
+        key = self._get_state_key(STATE_UV_NANO)
+        if (value := self.to_int_or_none(self._data.get(key))) is None:
+            return None
+        return self._update_feature(
+            AirConditionerFeatures.MODE_UN_NANO,
+            str(value) == UV_NANO_ON,
+            False,
+        )
+
+    @property
     def filters_life(self):
         """Return percentage status for all filters."""
         result = {}
@@ -1338,6 +1361,7 @@ class AirConditionerStatus(DeviceStatus):
             self.mode_airclean,
             self.mode_jet,
             self.lighting_display,
+            self.mode_uv_nano,
             self.water_in_current_temp,
             self.water_out_current_temp,
             self.mode_awhp_silent,


### PR DESCRIPTION
# Summary
This pull request implements a new mode called UV Nano for air conditioner. This mode utilizes an ultraviolet light to eliminate biological organisms. For more information, please refer to [LG's UV Nano Technology](https://www.lg.com/br/ar-condicionado-residencial/lg-s4-w24k2rxd).

# Entity
Create a switch entity to control the UV Nano mode.

# Tests
I have tested this on my air conditioner with the following scenarios and results:

- **Scenario**: Add device on Home Assistant via integration
  - *Expected*: A new entity called "Air UV Nano" is created.

- **Scenario**: Turn on from Home Assistant
  - *Expected*: Activate UV Nano mode.

- **Scenario**: Turn off from Home Assistant
  - *Expected*: Turn off UV Nano mode on the air conditioner.

- **Scenario**: Turn on from IR control
  - *Expected*: Update status on Home Assistant.

- **Scenario**: Turn off from IR control
  - *Expected*: Update status on Home Assistant.

All scenarios have passed successfully.

Since this is my first time creating or contributing to a custom component, I would greatly appreciate a code review or any suggestions to further improve this pull request.
