### PR TITLE
Modified for compatibility with Home Assistant 2024.4 and later

### DIFF
--- a/custom_components/smartthinq_sensors/manifest.json
+++ b/custom_components/smartthinq_sensors/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ollo69/ha-smartthinq-sensors/issues",
-  "requirements": ["pycountry<23.0.0,>=22.1.10", "xmltodict>=0.13.0", "charset_normalizer>=3.2.0"],
+  "requirements": [">=22.1.10", "xmltodict>=0.13.0", "charset_normalizer>=3.2.0"],
   "version": "0.38.7"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ isort==5.12.0
 black==23.1.0
 xmltodict>=0.13.0
 charset_normalizer>=3.2.0
-pycountry<23.0.0,>=22.1.10
+pycountry>=22.1.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,4 +6,4 @@ pytest-homeassistant-custom-component==0.13.85
 # From our manifest.json for our custom component
 xmltodict>=0.13.0
 charset_normalizer>=3.2.0
-pycountry<23.0.0,>=22.1.10
+pycountry>=22.1.10


### PR DESCRIPTION
I removed the check to make sure the version of upcountry is not greater than 23.0.0. Now it only checks if the version of pycountry is >=22.1.0