### PR TITLE
Fixes LG Range Hood with APIv2

### DIFF
--- a/custom_components/smartthinq_sensors/wideq/devices/hood.py
+++ b/custom_components/smartthinq_sensors/wideq/devices/hood.py
@@ -39,7 +39,7 @@ CMD_VENTLAMP_V2_DICT = {
     "ctrlKey": CMD_SET_VENTLAMP,
     KEY_DATASET: {
         KEY_HOODSTATE: {
-            "contentType": 22,
+            "contentType": 34,
             "dataLength": 5,
             CMD_VENTTIMER: 0,
         }


### PR DESCRIPTION
Fixes https://github.com/ollo69/ha-smartthinq-sensors/issues/394#issuecomment-2035622060 for LG Range Hood with APIv2.