### PR TITLE
Define ON/OFF in fan feature list

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/custom_components/smartthinq_sensors/const.py
+++ b/custom_components/smartthinq_sensors/const.py
@@ -7,7 +7,7 @@ ISSUE_URL = f"{PROJECT_URL}issues"
 DOMAIN = "smartthinq_sensors"
 
 MIN_HA_MAJ_VER = 2024
-MIN_HA_MIN_VER = 2
+MIN_HA_MIN_VER = 8
 __min_ha_version__ = f"{MIN_HA_MAJ_VER}.{MIN_HA_MIN_VER}.0"
 
 # general sensor attributes

--- a/custom_components/smartthinq_sensors/fan.py
+++ b/custom_components/smartthinq_sensors/fan.py
@@ -301,7 +301,7 @@ class LGEFan(LGEBaseFan):
     @property
     def supported_features(self) -> FanEntityFeature:
         """Return the list of supported features."""
-        features = FanEntityFeature(0)
+        features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
         if self.speed_count > 1:
             features |= FanEntityFeature.SET_SPEED
         if self.preset_modes is not None:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SmartThinQ LGE Sensors",
   "content_in_root": false,
-  "homeassistant": "2024.2.0"
+  "homeassistant": "2024.8.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Home Assistant Core
 colorlog==6.8.2
-homeassistant==2024.8.0
+homeassistant==2024.8.3
 pip>=21.3.1
 ruff==0.0.261
 pre-commit==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Home Assistant Core
 colorlog==6.8.2
-homeassistant==2024.2.4
+homeassistant==2024.8.0
 pip>=21.3.1
 ruff==0.0.261
 pre-commit==3.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 # Strictly for tests
-pytest==7.4.4
+pytest==8.3.1
 #pytest-cov==2.9.0
 #pytest-homeassistant
 pytest-homeassistant-custom-component==0.13.155

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 pytest==7.4.4
 #pytest-cov==2.9.0
 #pytest-homeassistant
-pytest-homeassistant-custom-component==0.13.103
+pytest-homeassistant-custom-component==0.13.155
 # From our manifest.json for our custom component
 xmltodict>=0.13.0
 charset_normalizer>=3.2.0


### PR DESCRIPTION
This PR in hass-core (https://github.com/home-assistant/core/pull/121447) stipulates that fan entities need to set ON/OFF feature flag if on/off operation is supported (milestone 2024.8.0b0). This PR just adds those two feature values and would address https://github.com/ollo69/ha-smartthinq-sensors/issues/783.

https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/

Closes #783