### PR TITLE
range: add oven timers and cook timers

### DIFF
--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -392,6 +392,50 @@ RANGE_SENSORS: tuple[ThinQSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         unit_fn=lambda x: x.oven_temp_unit,
     ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_UPPER_TIMER_TIME,
+        name="Oven upper timer",
+        icon="mdi:timer-outline",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_UPPER_TIMER_STATE,
+        name="Oven upper timer state",
+        icon="mdi:timer-cog-outline",
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_UPPER_COOK_TIMER_TIME,
+        name="Oven upper cook time",
+        icon="mdi:timer-check-outline",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_UPPER_COOK_TIMER_STATE,
+        name="Oven upper cook time state",
+        icon="mdi:timer-cog-outline",
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_LOWER_TIMER_TIME,
+        name="Oven lower timer",
+        icon="mdi:timer-outline",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_LOWER_TIMER_STATE,
+        name="Oven lower timer state",
+        icon="mdi:timer-cog-outline",
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_LOWER_COOK_TIMER_TIME,
+        name="Oven lower cook time",
+        icon="mdi:timer-check-outline",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    ),
+    ThinQSensorEntityDescription(
+        key=RangeFeatures.OVEN_LOWER_COOK_TIMER_STATE,
+        name="Oven lower cook time state",
+        icon="mdi:timer-cog-outline",
+    ),
 )
 AIR_PURIFIER_SENSORS: tuple[ThinQSensorEntityDescription, ...] = (
     ThinQSensorEntityDescription(

--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -96,6 +96,14 @@ class RangeFeatures(StrEnum):
     OVEN_UPPER_CURRENT_TEMP = "oven_upper_current_temp"
     OVEN_UPPER_MODE = "oven_upper_mode"
     OVEN_UPPER_STATE = "oven_upper_state"
+    OVEN_UPPER_TIMER_TIME = "oven_upper_timer"
+    OVEN_UPPER_COOK_TIMER_TIME = "oven_upper_cook_time"
+    OVEN_LOWER_TIMER_TIME = "oven_lower_timer"
+    OVEN_LOWER_COOK_TIMER_TIME = "oven_lower_cook_time"
+    OVEN_UPPER_TIMER_STATE = "oven_upper_timer_state"
+    OVEN_UPPER_COOK_TIMER_STATE = "oven_upper_cook_timer_state"
+    OVEN_LOWER_TIMER_STATE = "oven_lower_timer_state"
+    OVEN_LOWER_COOK_TIMER_STATE = "oven_lower_cook_timer_state"
 
 
 class RefrigeratorFeatures(StrEnum):


### PR DESCRIPTION
This change adds timestamp device sensors for upper/lower oven timers and cook times, and respective "on"/"off" state sensors. When no timer is set, timer finish time is set to beginning of current day.

![ha lg range timer](https://github.com/user-attachments/assets/c425f7ad-3dfc-47c3-b290-65609d496bfc)

resolves #454 