### PR TITLE
feat: add washer energy consumption sensors

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -331,8 +331,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UNSUPPORTED_DEVICES: unsupported_devices,
         DISCOVERED_DEVICES: discovered_devices,
     }
-    await hass.config_entries.async_forward_entry_setups(entry, SMARTTHINQ_PLATFORMS)
 
+    await hass.config_entries.async_forward_entry_setups(entry, SMARTTHINQ_PLATFORMS)
     start_devices_discovery(hass, entry, client)
 
     return True

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
     EntityCategory,
+    UnitOfEnergy,
     UnitOfPower,
     UnitOfTime,
 )
@@ -181,6 +182,38 @@ WASH_DEV_SENSORS: tuple[ThinQSensorEntityDescription, ...] = (
         icon="mdi:clock-outline",
         value_fn=lambda x: x.reserve_time,
         entity_registry_enabled_default=False,
+    ),
+    ThinQSensorEntityDescription(
+        key=WashDeviceFeatures.ENERGY_ACCUMULATED,
+        name="Energy total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:lightning-bolt",
+    ),
+    ThinQSensorEntityDescription(
+        key=WashDeviceFeatures.ENERGY_TODAY,
+        name="Energy today",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:calendar-today",
+    ),
+    ThinQSensorEntityDescription(
+        key=WashDeviceFeatures.ENERGY_THIS_MONTH,
+        name="Energy this month",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:calendar-month",
+        entity_registry_enabled_default=False,
+    ),
+    ThinQSensorEntityDescription(
+        key=WashDeviceFeatures.ENERGY_LAST_CYCLE,
+        name="Energy last cycle",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        icon="mdi:washing-machine",
     ),
 )
 REFRIGERATOR_SENSORS: tuple[ThinQSensorEntityDescription, ...] = (

--- a/custom_components/smartthinq_sensors/wideq/const.py
+++ b/custom_components/smartthinq_sensors/wideq/const.py
@@ -158,6 +158,10 @@ class WashDeviceFeatures(StrEnum):
     TUBCLEAN_COUNT = "tubclean_count"
     TURBOWASH = "turbo_wash"
     WATERTEMP = "water_temp"
+    ENERGY_ACCUMULATED = "energy_accumulated"
+    ENERGY_TODAY = "energy_today"
+    ENERGY_THIS_MONTH = "energy_this_month"
+    ENERGY_LAST_CYCLE = "energy_last_cycle"
 
 
 class WaterHeaterFeatures(StrEnum):

--- a/custom_components/smartthinq_sensors/wideq/core_async.py
+++ b/custom_components/smartthinq_sensors/wideq/core_async.py
@@ -1410,6 +1410,45 @@ class Session:
         """Get a device's settings based on api V2."""
         return await self.get2(f"service/devices/{device_id}")
 
+    async def get_energy_history(
+        self,
+        device_id: str,
+        period: str = "day",
+        start_date: str = "",
+        end_date: str = "",
+        service_type: str = "aircon",
+    ) -> dict:
+        """Get energy consumption history.
+
+        Args:
+            device_id: Target device ID
+            period: Period type - "hour", "day", or "month"
+            start_date: Start date in YYYY-MM-DD format (defaults to today)
+            end_date: End date in YYYY-MM-DD format (defaults to today)
+            service_type: Service path - "aircon" for AC, "laundry" for washers/dryers
+
+        Returns:
+            Dict with summary fields and "item" list of energy history entries
+        """
+        if not start_date:
+            start_date = datetime.now().strftime("%Y-%m-%d")
+        if not end_date:
+            end_date = datetime.now().strftime("%Y-%m-%d")
+
+        if service_type == "laundry":
+            path = (
+                f"service/laundry/{device_id}/energy-history"
+                f"?type=period&period={period}"
+                f"&startDate={start_date}&endDate={end_date}"
+                f"&washerType=M&twinYn=N"
+            )
+        else:
+            path = (
+                f"service/aircon/{device_id}/energy-history"
+                f"?period={period}&startDate={start_date}&endDate={end_date}"
+            )
+        return await self.get2(path)
+
     async def delete_permission(self, device_id):
         """Delete permission on V1 device after a control command."""
         await self.post("rti/delControlPermission", {"deviceId": device_id})


### PR DESCRIPTION
Add energy monitoring sensors for washer/dryer devices:
- Energy total (TOTAL_INCREASING): cumulative daily energy from hourly API
- Energy today (TOTAL): current day energy consumption
- Energy this month (TOTAL, disabled by default): monthly aggregate
- Energy last cycle: per-cycle average from last 7 days

Implementation:
- New get_energy_history() API method in Session (core_async.py)
- Energy polling via _additional_poll() with 300s interval
- Helper methods: _fetch_energy_items(), _sum_energy()
- WMStatus properties with _energy_feature() helper
- WashDeviceFeatures enum entries for all 4 energy types
- strings.json for config flow translations
- CI workflow updates and .gitignore additions

Closes #897 