### PR TITLE
Expose LG nature fan speed as auto

### DIFF
--- a/custom_components/smartthinq_sensors/climate.py
+++ b/custom_components/smartthinq_sensors/climate.py
@@ -14,7 +14,6 @@ from homeassistant.components.climate.const import (
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     FAN_AUTO,
-    FAN_DIFFUSE,
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
@@ -64,9 +63,10 @@ FAN_MODE_LOOKUP: dict[str, str] = {
     ACFanSpeed.HIGH.name: FAN_HIGH,
     ACFanSpeed.LOW.name: FAN_LOW,
     ACFanSpeed.MID.name: FAN_MEDIUM,
-    ACFanSpeed.NATURE.name: FAN_DIFFUSE,
+    ACFanSpeed.NATURE.name: FAN_AUTO,
 }
 FAN_MODE_REVERSE_LOOKUP = {v: k for k, v in FAN_MODE_LOOKUP.items()}
+FAN_MODE_REVERSE_LOOKUP[FAN_AUTO] = ACFanSpeed.AUTO.name
 
 PRESET_MODE_LOOKUP: dict[str, dict[str, HVACMode]] = {
     ACMode.ENERGY_SAVING.name: {"preset": PRESET_ECO, "hvac": HVACMode.COOL},
@@ -382,7 +382,10 @@ class LGEACClimate(LGEClimate):
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
-        lg_fan_mode = FAN_MODE_REVERSE_LOOKUP.get(fan_mode, fan_mode)
+        if fan_mode == FAN_AUTO and ACFanSpeed.NATURE.name in self._device.fan_speeds:
+            lg_fan_mode = ACFanSpeed.NATURE.name
+        else:
+            lg_fan_mode = FAN_MODE_REVERSE_LOOKUP.get(fan_mode, fan_mode)
         if lg_fan_mode not in self._device.fan_speeds:
             raise ValueError(f"Invalid fan mode [{fan_mode}]")
         await self._device.set_fan_speed(lg_fan_mode)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,48 @@
+"""Test the SmartThinQ sensors climate platform."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from homeassistant.components.climate.const import FAN_AUTO
+
+from custom_components.smartthinq_sensors.climate import (
+    FAN_MODE_LOOKUP,
+    ACFanSpeed,
+    LGEACClimate,
+)
+
+
+def _mock_ac_climate(fan_speeds: list[str]) -> LGEACClimate:
+    """Create a minimal mocked AC climate entity."""
+    climate = LGEACClimate.__new__(LGEACClimate)
+    climate._api = SimpleNamespace(async_set_updated=Mock())
+    climate._device = SimpleNamespace(
+        fan_speeds=fan_speeds,
+        set_fan_speed=AsyncMock(),
+    )
+    return climate
+
+
+def test_nature_fan_speed_maps_to_auto() -> None:
+    """Test LG nature fan speed is exposed as HA auto fan mode."""
+    assert FAN_MODE_LOOKUP[ACFanSpeed.NATURE.name] == FAN_AUTO
+
+
+async def test_set_auto_fan_mode_prefers_nature_when_supported() -> None:
+    """Test setting auto uses LG nature fan speed when available."""
+    climate = _mock_ac_climate([ACFanSpeed.LOW.name, ACFanSpeed.NATURE.name])
+
+    await climate.async_set_fan_mode(FAN_AUTO)
+
+    climate._device.set_fan_speed.assert_awaited_once_with(ACFanSpeed.NATURE.name)
+    climate._api.async_set_updated.assert_called_once_with()
+
+
+async def test_set_auto_fan_mode_uses_auto_when_nature_is_unsupported() -> None:
+    """Test setting auto keeps using LG auto fan speed without nature support."""
+    climate = _mock_ac_climate([ACFanSpeed.LOW.name, ACFanSpeed.AUTO.name])
+
+    await climate.async_set_fan_mode(FAN_AUTO)
+
+    climate._device.set_fan_speed.assert_awaited_once_with(ACFanSpeed.AUTO.name)
+    climate._api.async_set_updated.assert_called_once_with()


### PR DESCRIPTION
## Summary

Expose LG AC `NATURE` fan speed as Home Assistant `auto` instead of `diffuse`.

## Why

Automatic fan speed is unavailable on Apple Home. Some LG mini split models report their automatic fan behavior as `NATURE`, which currently becomes `diffuse` in Home Assistant. Since this is the device-managed fan mode, exposing it as standard `FAN_AUTO` lets Home Assistant and HomeKit Bridge represent it as automatic fan control.

When setting `fan_mode: auto`, this keeps the existing LG `AUTO` fallback, but prefers `NATURE` when the device supports it.

## Tests

- `pytest tests/test_climate.py`
- `pytest`
- `black --line-length 88 --diff --check custom_components/smartthinq_sensors/climate.py tests/test_climate.py`
- `isort --diff --check custom_components/smartthinq_sensors/climate.py tests/test_climate.py`
- `flake8 --extend-ignore=E704 custom_components/smartthinq_sensors/climate.py tests/test_climate.py`
