### PR TITLE
Update Polish translation

### DIFF
--- a/custom_components/smartthinq_sensors/translations/pl.json
+++ b/custom_components/smartthinq_sensors/translations/pl.json
@@ -4,6 +4,7 @@
             "single_instance_allowed": "Dozwolona jest tylko jedna konfiguracja SmartThinQ LGE Sensors.",
             "no_smartthinq_devices": "Nie znaleziono urządzeń SmartThinQ. Konfiguracja komponentów przerwana.",
             "unsupported_version": "Ta integracja wymaga HomeAssistanta w wersji co najmniej {req_ver}, Ty korzystasz z wersji {run_ver}.",
+            "reauth_successful": "Konfiguracja zakończona sukcesem.",
             "reconfigured": "Konfiguracja zakończona sukcesem."
         },
         "error": {
@@ -25,6 +26,7 @@
                     "region": "Region",
                     "language": "Język",
                     "use_redirect": "Użyj metody bezpośredniego uwierzytelniania",
+                    "use_ha_session": "Udostępnij połączenie HTTP Home Assistant (może powodować błędy SSL)",
                     "use_tls_v1": "Wymuś użycie protokołu TLSv1 (czasami wymagane)",
                     "exclude_dh": "Nie używaj szyfrowania DH (w przypadku błędu 'dh key too small')"
                 },
@@ -35,7 +37,7 @@
                     "login_url": "URL logowania SmartThinQ",
                     "callback_url": "URL przekierowania"
                 },
-                "description": "Skopiuj i otwórz adres URL z pierwszego pola, aby zalogować się do SmartThinQ, a następnie po zalogowaniu się na konto SmartThinQ w drugie pole wklej adres URL, na który przekierowała cię przeglądarka po zalogowaniu.",
+                "description": "Skopiuj i otwórz adres URL z pierwszego pola, aby zalogować się do SmartThinQ, a następnie po zalogowaniu się na konto SmartThinQ w drugie pole wklej adres URL, na który przekierowała cię przeglądarka po zalogowaniu. Podziel się opinią o swojej konfiguracji [here]({pat_url}).",
                 "title": "Sensory SmartThinQ LGE - Autoryzacja"
             },
             "token": {
@@ -44,6 +46,13 @@
                 },
                 "description": "Zapisz wygenerowany token, może się przydać w przyszłości, a następnie potwierdź, aby zakończyć konfigurację.",
                 "title": "SmartThinQ LGE Sensors - token został zapisany"
+            },
+            "reauth_confirm": {
+                "data": {
+                    "reauth_cred": "Zaznacz tę opcję, jeśli musisz wprowadzić nowe dane logowania do ThinQ"
+                },
+                "title": "Sensory SmartThinQ LGE - ponowne uwierzytelnienie",
+                "description": "Błąd nieprawidłowych danych logowania ThinQ, konfiguracja integracji została przerwana. Użyj aplikacji LG na urządzeniu mobilnym i sprawdź, czy nie ma nowych Warunków Usług do zaakceptowania, a następnie naciśnij OK, aby ponownie załadować integrację."
             }
         },
         "title": "Sensory SmartThinQ LGE"


### PR DESCRIPTION
This MR updates the Polish translation file and addresses the following issues:

- Added missing translation keys
- Fixed the following Home Assistant log error:

`Validation of translation placeholders for localized (pl) string component.smartthinq_sensors.config.step.url.description failed: (set() != {'pat_url'})`