### PR TITLE
Configurable scan interval (OptionsFlow + number entity)

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -378,12 +378,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # If LG never connected, only the number platform was forwarded; trying to
     # unload the LG-dependent platforms in that case errors out per-platform.
     lg_loaded = CLIENT in hass.data.get(DOMAIN, {})
-    platforms = (
-        SMARTTHINQ_PLATFORMS if lg_loaded else [Platform.NUMBER]
-    )
-    if unload_ok := await hass.config_entries.async_unload_platforms(
-        entry, platforms
-    ):
+    platforms = SMARTTHINQ_PLATFORMS if lg_loaded else [Platform.NUMBER]
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
         data = hass.data.pop(DOMAIN)
         reload = data.get(SIGNAL_RELOAD_ENTRY, 0)
         if reload > 0:

--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -35,8 +35,10 @@ from .const import (
     CLIENT,
     CONF_LANGUAGE,
     CONF_OAUTH2_URL,
+    CONF_SCAN_INTERVAL,
     CONF_USE_API_V2,
     CONF_USE_HA_SESSION,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LGE_DEVICES,
     LGE_DISCOVERY_NEW,
@@ -68,6 +70,7 @@ SMARTTHINQ_PLATFORMS = [
     Platform.FAN,
     Platform.HUMIDIFIER,
     Platform.LIGHT,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
@@ -83,7 +86,6 @@ SIGNAL_RELOAD_ENTRY = f"{DOMAIN}_reload_entry"
 DISCOVERED_DEVICES = "discovered_devices"
 UNSUPPORTED_DEVICES = "unsupported_devices"
 
-SCAN_INTERVAL = timedelta(seconds=30)
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -230,9 +232,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
 
-    log_info: bool = hass.data.get(DOMAIN, {}).get(SIGNAL_RELOAD_ENTRY, 0) < 2
+    # Forward the scan_interval number entity before any LG call so users can
+    # adjust the polling rate even when the LG cloud is unreachable.
+    hass.data.setdefault(DOMAIN, {})[CONF_SCAN_INTERVAL] = int(
+        entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    )
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.NUMBER])
+    entry.async_on_unload(entry.add_update_listener(_options_update_listener))
+
+    log_info: bool = hass.data[DOMAIN].get(SIGNAL_RELOAD_ENTRY, 0) < 2
     if log_info:
-        hass.data[DOMAIN] = {SIGNAL_RELOAD_ENTRY: 2}
+        hass.data[DOMAIN][SIGNAL_RELOAD_ENTRY] = 2
         _LOGGER.info(STARTUP)
         _LOGGER.info(
             "Initializing ThinQ platform with region: %s - language: %s",
@@ -269,12 +279,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning(msg, exc_info=True)
         raise ConfigEntryNotReady(msg) from exc
 
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         if log_info:
             _LOGGER.warning(
-                "Connection not available. ThinQ platform not ready", exc_info=True
+                "Connection not available. ThinQ platform not ready", exc_info=exc
             )
-        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
+        # Keep the entry loaded so the number entity is usable and the user
+        # can adjust scan_interval; reload the entry once LG is reachable.
+        return True
 
     if not client.has_devices:
         _LOGGER.error("No ThinQ devices found. Component setup aborted")
@@ -286,17 +298,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         lge_devices, unsupported_devices, discovered_devices = await lge_devices_setup(
             hass, client
         )
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         if log_info:
             _LOGGER.warning(
-                "Connection not available. ThinQ platform not ready", exc_info=True
+                "Connection not available. ThinQ platform not ready", exc_info=exc
             )
         await client.close()
-        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
+        return True
 
     if discovered_devices is None:
         await client.close()
-        raise ConfigEntryNotReady("ThinQ platform not ready: no devices found.")
+        _LOGGER.warning("ThinQ platform not ready: no devices found")
+        return True
 
     # remove device not available anymore
     dev_ids = [v for ids in discovered_devices.values() for v in ids]
@@ -321,29 +334,62 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close_lg_client)
     )
 
-    hass.data[DOMAIN] = {
-        CLIENT: client,
-        LGE_DEVICES: lge_devices,
-        UNSUPPORTED_DEVICES: unsupported_devices,
-        DISCOVERED_DEVICES: discovered_devices,
-    }
-    await hass.config_entries.async_forward_entry_setups(entry, SMARTTHINQ_PLATFORMS)
+    # update() (not assignment) preserves the CONF_SCAN_INTERVAL seeded earlier.
+    hass.data[DOMAIN].update(
+        {
+            CLIENT: client,
+            LGE_DEVICES: lge_devices,
+            UNSUPPORTED_DEVICES: unsupported_devices,
+            DISCOVERED_DEVICES: discovered_devices,
+        }
+    )
+    await hass.config_entries.async_forward_entry_setups(
+        entry, [p for p in SMARTTHINQ_PLATFORMS if p is not Platform.NUMBER]
+    )
 
     start_devices_discovery(hass, entry, client)
 
     return True
 
 
+async def _options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Apply OptionsFlow changes to running coordinators without a reload."""
+    new_interval = int(entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+    domain_data = hass.data.get(DOMAIN, {})
+    if domain_data.get(CONF_SCAN_INTERVAL) == new_interval:
+        return
+    domain_data[CONF_SCAN_INTERVAL] = new_interval
+    delta = timedelta(seconds=new_interval)
+    for devices in domain_data.get(LGE_DEVICES, {}).values():
+        for lge_device in devices:
+            if lge_device.coordinator is not None:
+                lge_device.coordinator.update_interval = delta
+                # Reschedule so the new interval takes effect immediately
+                # rather than waiting out the old one.
+                if lge_device.coordinator.data is not None:
+                    lge_device.coordinator.async_set_updated_data(
+                        lge_device.coordinator.data
+                    )
+    _LOGGER.info("ThinQ scan interval updated to %d seconds", new_interval)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    # If LG never connected, only the number platform was forwarded; trying to
+    # unload the LG-dependent platforms in that case errors out per-platform.
+    lg_loaded = CLIENT in hass.data.get(DOMAIN, {})
+    platforms = (
+        SMARTTHINQ_PLATFORMS if lg_loaded else [Platform.NUMBER]
+    )
     if unload_ok := await hass.config_entries.async_unload_platforms(
-        entry, SMARTTHINQ_PLATFORMS
+        entry, platforms
     ):
         data = hass.data.pop(DOMAIN)
         reload = data.get(SIGNAL_RELOAD_ENTRY, 0)
         if reload > 0:
             hass.data[DOMAIN] = {SIGNAL_RELOAD_ENTRY: reload}
-        await data[CLIENT].close()
+        if (client := data.get(CLIENT)) is not None:
+            await client.close()
     return unload_ok
 
 
@@ -465,13 +511,16 @@ class LGEDevice:
 
     async def _create_coordinator(self) -> None:
         """Get the coordinator for a specific device."""
+        interval = self._hass.data.get(DOMAIN, {}).get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
         coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
             self._hass,
             _LOGGER,
             name=f"{DOMAIN}-{self._name}",
             update_method=self._async_update,
             # Polling interval. Will only be polled if there are subscribers.
-            update_interval=SCAN_INTERVAL,
+            update_interval=timedelta(seconds=interval),
         )
         await coordinator.async_refresh()
         self._coordinator = coordinator

--- a/custom_components/smartthinq_sensors/config_flow.py
+++ b/custom_components/smartthinq_sensors/config_flow.py
@@ -13,9 +13,11 @@ import voluptuous as vol
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_POLL,
     SOURCE_REAUTH,
+    ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
+    OptionsFlow,
 )
 from homeassistant.const import (
     CONF_BASE,
@@ -28,6 +30,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -41,10 +46,14 @@ from . import LGEAuthentication, is_valid_ha_version
 from .const import (
     CONF_LANGUAGE,
     CONF_OAUTH2_URL,
+    CONF_SCAN_INTERVAL,
     CONF_USE_API_V2,
     CONF_USE_HA_SESSION,
     CONF_USE_REDIRECT,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
     __min_ha_version__,
 )
 from .wideq.core_exceptions import AuthenticationError, InvalidCredentialError
@@ -79,6 +88,12 @@ class SmartThinQFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler."""
+        return SmartThinQOptionsFlowHandler()
 
     def __init__(self) -> None:
         """Initialize flow."""
@@ -391,3 +406,32 @@ def _dict_to_select(opt_dict: dict) -> SelectSelectorConfig:
         options=[SelectOptionDict(value=str(k), label=v) for k, v in opt_dict.items()],
         mode=SelectSelectorMode.DROPDOWN,
     )
+
+
+class SmartThinQOptionsFlowHandler(OptionsFlow):
+    """Handle the SmartThinQ options flow (per-entry configurable settings)."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_SCAN_INTERVAL, default=current): NumberSelector(
+                    NumberSelectorConfig(
+                        min=MIN_SCAN_INTERVAL,
+                        max=MAX_SCAN_INTERVAL,
+                        step=1,
+                        mode=NumberSelectorMode.BOX,
+                        unit_of_measurement="s",
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/smartthinq_sensors/const.py
+++ b/custom_components/smartthinq_sensors/const.py
@@ -38,6 +38,15 @@ CONF_USE_API_V2 = "use_api_v2"
 CONF_USE_HA_SESSION = "use_ha_session"
 CONF_USE_REDIRECT = "use_redirect"
 
+# Polling interval (seconds) - user-adjustable via OptionsFlow / number entity.
+# LG cloud blocks accounts that poll too aggressively. Default raised from
+# the original hardcoded 30 s to 300 s (5 min) so fresh installs and existing
+# users without an explicit override avoid the ban.
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 300
+MIN_SCAN_INTERVAL = 30
+MAX_SCAN_INTERVAL = 3600
+
 CLIENT = "client"
 LGE_DEVICES = "lge_devices"
 

--- a/custom_components/smartthinq_sensors/number.py
+++ b/custom_components/smartthinq_sensors/number.py
@@ -49,9 +49,7 @@ class SmartThinQScanIntervalNumber(NumberEntity):
         async def _options_changed(_hass: HomeAssistant, _entry: ConfigEntry) -> None:
             self.async_write_ha_state()
 
-        self.async_on_remove(
-            self._config_entry.add_update_listener(_options_changed)
-        )
+        self.async_on_remove(self._config_entry.add_update_listener(_options_changed))
 
     @property
     def native_value(self) -> float:

--- a/custom_components/smartthinq_sensors/number.py
+++ b/custom_components/smartthinq_sensors/number.py
@@ -1,0 +1,68 @@
+"""Number platform exposing the SmartThinQ scan_interval option."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the scan_interval number entity for this config entry."""
+    async_add_entities([SmartThinQScanIntervalNumber(config_entry)])
+
+
+class SmartThinQScanIntervalNumber(NumberEntity):
+    """Polling interval (seconds) shared by all SmartThinQ coordinators."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "scan_interval"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+    _attr_native_min_value = MIN_SCAN_INTERVAL
+    _attr_native_max_value = MAX_SCAN_INTERVAL
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_icon = "mdi:timer-cog-outline"
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize."""
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{config_entry.entry_id}-scan_interval"
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh state whenever the option is changed via OptionsFlow."""
+
+        async def _options_changed(_hass: HomeAssistant, _entry: ConfigEntry) -> None:
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            self._config_entry.add_update_listener(_options_changed)
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the current interval (seconds)."""
+        return float(
+            self._config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist the new interval; the options listener picks it up live."""
+        self.hass.config_entries.async_update_entry(
+            self._config_entry,
+            options={**self._config_entry.options, CONF_SCAN_INTERVAL: int(value)},
+        )

--- a/custom_components/smartthinq_sensors/translations/en.json
+++ b/custom_components/smartthinq_sensors/translations/en.json
@@ -56,5 +56,23 @@
       }
     },
     "title": "SmartThinQ LGE Sensors"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SmartThinQ options",
+        "description": "How often the integration polls the LG cloud (seconds). Default is 300 (5 min). Lower values risk a 24-hour LG account block. Increase if you have many devices or hit bans.",
+        "data": {
+          "scan_interval": "Scan interval (seconds)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "scan_interval": {
+        "name": "Scan interval"
+      }
+    }
   }
 }


### PR DESCRIPTION
Mitigates #961 / #963.

## Problem

The hardcoded 30s polling interval generates ~2,880 calls per device per day. With multiple devices on one LG account, this trips LG's automated-abuse detection and blocks the account for 24 hours (`UseOfficialAPIError` / `resultCode: 9012`). Users have no way to slow polling down without editing source - and once banned, the integration is stuck in setup-retry, which means even installing this fix offers no UI controls until the ban clears.

## What this changes

- **Default raised from 30s to 300s** (5 min).
- **OptionsFlow** at Settings → Devices & Services → SmartThinQ → Configure exposes a numeric input (30–3600s).
- **`number.smartthinq_scan_interval` entity** mirrors the same option so it's adjustable from automations and dashboards as well as the UI.
  - This allows lower frequency when sleeping/house unoccupied, higher when kitchen motion detected/laundry room door open, etc.
  - A future PR should allow per-device interval setting.
- **Live update**: changing the option reassigns the running `DataUpdateCoordinator.update_interval` in place and triggers an immediate `async_set_updated_data` reschedule - no entry reload, no re-auth, no extra API hit.
- **Number platform forwarded first**, before the LG auth call. On non-auth connection failures (LG unreachable / banned), `async_setup_entry` now returns `True` instead of raising `ConfigEntryNotReady`. The entry stays loaded, the number entity remains usable, and the user can fix the interval before LG ever comes back. `ConfigEntryAuthFailed` (bad credentials path) is unchanged.
- **Unload path fix**: `async_unload_entry` now scopes its `async_unload_platforms` call to the platforms that were actually forwarded (just `Platform.NUMBER` when LG never connected) and guards `client.close()` against a missing client. Avoids `Config entry was never loaded!` errors and stuck `failed_unload` state on a post-ban reload.

## Regarding the always-loaded behavior

This addresses the "I'm reading this PR because I just got banned" UX. Without the change, a freshly-installed fix is useless until the 24h ban clears, because `async_setup_entry` raises `ConfigEntryNotReady` on the failed LG auth and no platforms - including the number entity that exists *to fix this* - ever load.

With the change:

- Banned user installs the fix
- HA loads the integration → `number.smartthinq_scan_interval` shows up immediately
- LG-side failure logged once, entry returns True
- User opens OptionsFlow (or any automation/dashboard) and tweaks the interval; value lands in `entry.options`
- When LG accepts again, user reloads the entry once from Settings → Integrations; the LG-dependent platforms come up and devices appear

Trade-off vs the old behavior: HA no longer auto-retries the LG connection on a schedule. The user clicks Reload once when ready. In return, the entry isn't stuck in `setup_retry` for the whole 24h, and the OptionsFlow / number entity are usable the whole time.

## Regarding the runtime clamp design choice

Practice varies across HA integrations - many trust the UI's `NumberSelector` range and don't re-validate at runtime; some clamp defensively. The interval is clamped via `int()` on the option read; the OptionsFlow `NumberSelector` and the number entity's `_attr_native_min/max_value` both enforce 30–3600s at the UI level. I left out a runtime clamp helper for now to keep the diff minimal - happy to add one back if you'd prefer belt-and-suspenders given the consequence of a too-low value is a 24-hour account-wide lockout.

## Tested locally

End-to-end on a config entry where the LG account was in a 24h block:

1. With LG unreachable: `async_setup_entry` returned True; `number.smartthinq_scan_interval` registered as state=300; `number.set_value` from a REST service call updated it to 600; the options-update listener logged `ThinQ scan interval updated to 600 seconds`.
2. After the LG ban cleared: `POST /api/config/config_entries/entry/<id>/reload` returned `require_restart: false` and within seconds all device platforms forwarded successfully (climate, fan, humidifier, light, select, sensor, switch, water_heater). Washer / dryer / dishwasher came back as real states. **No HA restart was needed for the reload to succeed** - the unload-path fix worked as intended; without it the reload errors per-platform on the never-loaded `LGE_PLATFORMS` and parks the entry in `failed_unload` until restart.

## Files

- `const.py` - new `CONF_SCAN_INTERVAL`, `DEFAULT_SCAN_INTERVAL` (300), `MIN_SCAN_INTERVAL` (30), `MAX_SCAN_INTERVAL` (3600).
- `__init__.py` - adds `Platform.NUMBER` to `SMARTTHINQ_PLATFORMS`; forwards `[Platform.NUMBER]` and registers the options-update listener before the LG auth try block; changes the non-auth `except Exception` branches to `return True` instead of raising `ConfigEntryNotReady`; switches the post-success `hass.data[DOMAIN] = {...}` to `update()` so the seeded `CONF_SCAN_INTERVAL` survives; reads the interval from `hass.data` in `_create_coordinator`; new `_options_update_listener` mutates each coordinator's `update_interval` in place; `async_unload_entry` now scopes platforms to what was forwarded and guards `client.close()`.
- `config_flow.py` - `SmartThinQOptionsFlowHandler` with a single-step form using `NumberSelector`.
- `number.py` (new) - `SmartThinQScanIntervalNumber` entity, writes back to `entry.options` on user change.
- `translations/en.json` - strings for the new options step and entity.

## Notes

- Existing users with the previous hardcoded 30s default will silently move to 300s. That's the intended fix, but worth calling out in release notes.
- `MIN_TIME_BETWEEN_UPDATE = 25` in `wideq/core_async.py` is unrelated (gates `refresh_devices()`, not per-device polling) and is left untouched.
- Translations updated only for `en.json`. Other locale files would benefit from the same keys; happy to follow up if helpful.

