### PR TITLE
feat: add active scan interval for dynamic polling rate

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -33,11 +33,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CLIENT,
+    CONF_ACTIVE_SCAN_INTERVAL,
     CONF_LANGUAGE,
     CONF_OAUTH2_URL,
     CONF_SCAN_INTERVAL,
     CONF_USE_API_V2,
     CONF_USE_HA_SESSION,
+    DEFAULT_ACTIVE_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LGE_DEVICES,
@@ -234,8 +236,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Forward the scan_interval number entity before any LG call so users can
     # adjust the polling rate even when the LG cloud is unreachable.
-    hass.data.setdefault(DOMAIN, {})[CONF_SCAN_INTERVAL] = int(
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    domain_data[CONF_SCAN_INTERVAL] = int(
         entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    )
+    domain_data[CONF_ACTIVE_SCAN_INTERVAL] = int(
+        entry.options.get(CONF_ACTIVE_SCAN_INTERVAL, DEFAULT_ACTIVE_SCAN_INTERVAL)
     )
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.NUMBER])
     entry.async_on_unload(entry.add_update_listener(_options_update_listener))
@@ -355,22 +361,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Apply OptionsFlow changes to running coordinators without a reload."""
     new_interval = int(entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+    new_active_interval = int(
+        entry.options.get(CONF_ACTIVE_SCAN_INTERVAL, DEFAULT_ACTIVE_SCAN_INTERVAL)
+    )
     domain_data = hass.data.get(DOMAIN, {})
-    if domain_data.get(CONF_SCAN_INTERVAL) == new_interval:
+    if (
+        domain_data.get(CONF_SCAN_INTERVAL) == new_interval
+        and domain_data.get(CONF_ACTIVE_SCAN_INTERVAL) == new_active_interval
+    ):
         return
     domain_data[CONF_SCAN_INTERVAL] = new_interval
-    delta = timedelta(seconds=new_interval)
+    domain_data[CONF_ACTIVE_SCAN_INTERVAL] = new_active_interval
     for devices in domain_data.get(LGE_DEVICES, {}).values():
         for lge_device in devices:
             if lge_device.coordinator is not None:
-                lge_device.coordinator.update_interval = delta
+                lge_device._apply_scan_interval()
                 # Reschedule so the new interval takes effect immediately
                 # rather than waiting out the old one.
                 if lge_device.coordinator.data is not None:
                     lge_device.coordinator.async_set_updated_data(
                         lge_device.coordinator.data
                     )
-    _LOGGER.info("ThinQ scan interval updated to %d seconds", new_interval)
+    _LOGGER.info(
+        "ThinQ scan intervals updated: idle=%ds, active=%ds",
+        new_interval,
+        new_active_interval,
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -505,6 +521,20 @@ class LGEDevice:
         if self._coordinator:
             self._coordinator.async_set_updated_data(self._state)
 
+    def _apply_scan_interval(self) -> None:
+        """Set the coordinator interval based on whether the device is currently on."""
+        if not self._coordinator:
+            return
+        domain_data = self._hass.data.get(DOMAIN, {})
+        is_on = getattr(self._state, "is_on", False)
+        if is_on:
+            interval = domain_data.get(
+                CONF_ACTIVE_SCAN_INTERVAL, DEFAULT_ACTIVE_SCAN_INTERVAL
+            )
+        else:
+            interval = domain_data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        self._coordinator.update_interval = timedelta(seconds=interval)
+
     async def _create_coordinator(self) -> None:
         """Get the coordinator for a specific device."""
         interval = self._hass.data.get(DOMAIN, {}).get(
@@ -577,6 +607,7 @@ class LGEDevice:
             # _LOGGER.debug('Status attributes: %s', l)
             self._disc_count = 0
             self._state = state
+        self._apply_scan_interval()
 
 
 async def lge_devices_setup(

--- a/custom_components/smartthinq_sensors/config_flow.py
+++ b/custom_components/smartthinq_sensors/config_flow.py
@@ -44,15 +44,19 @@ from homeassistant.helpers.selector import (
 
 from . import LGEAuthentication, is_valid_ha_version
 from .const import (
+    CONF_ACTIVE_SCAN_INTERVAL,
     CONF_LANGUAGE,
     CONF_OAUTH2_URL,
     CONF_SCAN_INTERVAL,
     CONF_USE_API_V2,
     CONF_USE_HA_SESSION,
     CONF_USE_REDIRECT,
+    DEFAULT_ACTIVE_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_ACTIVE_SCAN_INTERVAL,
     MAX_SCAN_INTERVAL,
+    MIN_ACTIVE_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
     __min_ha_version__,
 )
@@ -418,15 +422,29 @@ class SmartThinQOptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        current = self.config_entry.options.get(
+        current_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        current_active_interval = self.config_entry.options.get(
+            CONF_ACTIVE_SCAN_INTERVAL, DEFAULT_ACTIVE_SCAN_INTERVAL
         )
         schema = vol.Schema(
             {
-                vol.Required(CONF_SCAN_INTERVAL, default=current): NumberSelector(
+                vol.Required(CONF_SCAN_INTERVAL, default=current_interval): NumberSelector(
                     NumberSelectorConfig(
                         min=MIN_SCAN_INTERVAL,
                         max=MAX_SCAN_INTERVAL,
+                        step=1,
+                        mode=NumberSelectorMode.BOX,
+                        unit_of_measurement="s",
+                    )
+                ),
+                vol.Required(
+                    CONF_ACTIVE_SCAN_INTERVAL, default=current_active_interval
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        min=MIN_ACTIVE_SCAN_INTERVAL,
+                        max=MAX_ACTIVE_SCAN_INTERVAL,
                         step=1,
                         mode=NumberSelectorMode.BOX,
                         unit_of_measurement="s",

--- a/custom_components/smartthinq_sensors/const.py
+++ b/custom_components/smartthinq_sensors/const.py
@@ -47,6 +47,13 @@ DEFAULT_SCAN_INTERVAL = 300
 MIN_SCAN_INTERVAL = 30
 MAX_SCAN_INTERVAL = 3600
 
+# Faster polling interval used while a device is actively running.
+# LG's API returns a 9006 rate-limit warning below ~35 s.
+CONF_ACTIVE_SCAN_INTERVAL = "active_scan_interval"
+DEFAULT_ACTIVE_SCAN_INTERVAL = 35
+MIN_ACTIVE_SCAN_INTERVAL = 30
+MAX_ACTIVE_SCAN_INTERVAL = 3600
+
 CLIENT = "client"
 LGE_DEVICES = "lge_devices"
 

--- a/custom_components/smartthinq_sensors/number.py
+++ b/custom_components/smartthinq_sensors/number.py
@@ -1,4 +1,4 @@
-"""Number platform exposing the SmartThinQ scan_interval option."""
+"""Number platform exposing SmartThinQ polling interval options."""
 
 from __future__ import annotations
 
@@ -9,9 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    CONF_ACTIVE_SCAN_INTERVAL,
     CONF_SCAN_INTERVAL,
+    DEFAULT_ACTIVE_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
+    MAX_ACTIVE_SCAN_INTERVAL,
     MAX_SCAN_INTERVAL,
+    MIN_ACTIVE_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
 )
 
@@ -21,27 +25,31 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the scan_interval number entity for this config entry."""
-    async_add_entities([SmartThinQScanIntervalNumber(config_entry)])
+    """Set up polling interval number entities for this config entry."""
+    async_add_entities(
+        [
+            SmartThinQScanIntervalNumber(config_entry),
+            SmartThinQActiveScanIntervalNumber(config_entry),
+        ]
+    )
 
 
-class SmartThinQScanIntervalNumber(NumberEntity):
-    """Polling interval (seconds) shared by all SmartThinQ coordinators."""
+class _ScanIntervalNumberBase(NumberEntity):
+    """Base class for SmartThinQ polling interval number entities."""
 
     _attr_has_entity_name = True
-    _attr_translation_key = "scan_interval"
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = NumberMode.BOX
-    _attr_native_min_value = MIN_SCAN_INTERVAL
-    _attr_native_max_value = MAX_SCAN_INTERVAL
-    _attr_native_step = 1
     _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_icon = "mdi:timer-cog-outline"
+
+    _conf_key: str
+    _default: int
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize."""
         self._config_entry = config_entry
-        self._attr_unique_id = f"{config_entry.entry_id}-scan_interval"
+        self._attr_unique_id = f"{config_entry.entry_id}-{self._conf_key}"
 
     async def async_added_to_hass(self) -> None:
         """Refresh state whenever the option is changed via OptionsFlow."""
@@ -54,13 +62,33 @@ class SmartThinQScanIntervalNumber(NumberEntity):
     @property
     def native_value(self) -> float:
         """Return the current interval (seconds)."""
-        return float(
-            self._config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        )
+        return float(self._config_entry.options.get(self._conf_key, self._default))
 
     async def async_set_native_value(self, value: float) -> None:
         """Persist the new interval; the options listener picks it up live."""
         self.hass.config_entries.async_update_entry(
             self._config_entry,
-            options={**self._config_entry.options, CONF_SCAN_INTERVAL: int(value)},
+            options={**self._config_entry.options, self._conf_key: int(value)},
         )
+
+
+class SmartThinQScanIntervalNumber(_ScanIntervalNumberBase):
+    """Idle polling interval — used when all devices are off."""
+
+    _attr_translation_key = "scan_interval"
+    _attr_native_min_value = MIN_SCAN_INTERVAL
+    _attr_native_max_value = MAX_SCAN_INTERVAL
+    _attr_native_step = 1
+    _conf_key = CONF_SCAN_INTERVAL
+    _default = DEFAULT_SCAN_INTERVAL
+
+
+class SmartThinQActiveScanIntervalNumber(_ScanIntervalNumberBase):
+    """Active polling interval — used while a device is running."""
+
+    _attr_translation_key = "active_scan_interval"
+    _attr_native_min_value = MIN_ACTIVE_SCAN_INTERVAL
+    _attr_native_max_value = MAX_ACTIVE_SCAN_INTERVAL
+    _attr_native_step = 1
+    _conf_key = CONF_ACTIVE_SCAN_INTERVAL
+    _default = DEFAULT_ACTIVE_SCAN_INTERVAL

--- a/custom_components/smartthinq_sensors/translations/en.json
+++ b/custom_components/smartthinq_sensors/translations/en.json
@@ -61,9 +61,14 @@
     "step": {
       "init": {
         "title": "SmartThinQ options",
-        "description": "How often the integration polls the LG cloud (seconds). Default is 300 (5 min). Lower values risk a 24-hour LG account block. Increase if you have many devices or hit bans.",
+        "description": "Configure polling rates. The idle interval is used when all devices are off. The active interval is used while a device is running. Lower active values give faster updates but risk LG account bans if set too aggressively.",
         "data": {
-          "scan_interval": "Scan interval (seconds)"
+          "scan_interval": "Idle scan interval (seconds)",
+          "active_scan_interval": "Active scan interval (seconds)"
+        },
+        "data_description": {
+          "scan_interval": "How often to poll when devices are off. Default: 300 s (5 min). Min: 30 s.",
+          "active_scan_interval": "How often to poll while a device is running. Default: 35 s. Min: 30 s."
         }
       }
     }
@@ -71,7 +76,10 @@
   "entity": {
     "number": {
       "scan_interval": {
-        "name": "Scan interval"
+        "name": "Idle scan interval"
+      },
+      "active_scan_interval": {
+        "name": "Active scan interval"
       }
     }
   }


### PR DESCRIPTION
Introduce a separate polling interval that activates while a device is running, replacing the single static scan interval.

- Add CONF_ACTIVE_SCAN_INTERVAL constant (default 35s, min 30s, max 3600s); LG's API returns a 9006 rate-limit warning at exactly 30s
- Add LGEDevice._apply_scan_interval() which switches each device's coordinator between the idle and active interval based on is_on state; called after every poll so the transition is immediate on the next cycle
- Expose both intervals as config-category number entities and in the options flow so they can be adjusted from the UI without a reload
- Update _options_update_listener to re-apply per-device intervals when either setting changes, rather than blindly writing one delta to all coordinators