### PR TITLE
Handle the V1 control permission instead of failing with error 0011

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -385,6 +385,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if reload > 0:
             hass.data[DOMAIN] = {SIGNAL_RELOAD_ENTRY: reload}
         if (client := data.get(CLIENT)) is not None:
+            # Hand back any V1 control permission we are holding. Only the
+            # session that took it can release it, so one left behind here
+            # locks the device for the ThinQ app and for our own next start.
+            for devices in data.get(LGE_DEVICES, {}).values():
+                for lge_device in devices:
+                    await lge_device.device.release_control_permission()
             await client.close()
     return unload_ok
 

--- a/custom_components/smartthinq_sensors/button.py
+++ b/custom_components/smartthinq_sensors/button.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import LGEBaseDevice
+from .device_helpers import LGEBaseDevice, handle_api_errors
 from .wideq import WM_DEVICE_TYPES, WashDeviceFeatures
 
 # general button attributes
@@ -143,6 +143,7 @@ class LGEButton(CoordinatorEntity, ButtonEntity):
             is_avail = self.entity_description.available_fn(self._wrap_device)
         return self._api.available and is_avail
 
+    @handle_api_errors
     async def async_press(self) -> None:
         """Triggers service."""
         await self.entity_description.press_action_fn(self._wrap_device)

--- a/custom_components/smartthinq_sensors/climate.py
+++ b/custom_components/smartthinq_sensors/climate.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import TEMP_UNIT_LOOKUP, LGERefrigeratorDevice
+from .device_helpers import TEMP_UNIT_LOOKUP, LGERefrigeratorDevice, handle_api_errors
 from .wideq import AirConditionerFeatures, DeviceType, TemperatureUnit
 from .wideq.devices.ac import (
     AWHP_MAX_TEMP,
@@ -296,6 +296,7 @@ class LGEACClimate(LGEClimate):
         modes = self._available_hvac_modes()
         return modes.get(op_mode, HVACMode.AUTO)
 
+    @handle_api_errors
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
@@ -320,6 +321,7 @@ class LGEACClimate(LGEClimate):
         modes = self._available_hvac_modes()
         return [HVACMode.OFF] + list(modes.values())
 
+    @handle_api_errors
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if not (modes := self._available_preset_modes()):
@@ -363,6 +365,7 @@ class LGEACClimate(LGEClimate):
         """Return the temperature we try to reach."""
         return self._api.state.target_temp
 
+    @handle_api_errors
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
@@ -380,6 +383,7 @@ class LGEACClimate(LGEClimate):
         speed = self._api.state.fan_speed
         return FAN_MODE_LOOKUP.get(speed, speed)
 
+    @handle_api_errors
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         lg_fan_mode = FAN_MODE_REVERSE_LOOKUP.get(fan_mode, fan_mode)
@@ -395,6 +399,7 @@ class LGEACClimate(LGEClimate):
             return self._api.state.horizontal_step_mode
         return self._api.state.vertical_step_mode
 
+    @handle_api_errors
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         if swing_mode not in (self.swing_modes or []):
@@ -412,6 +417,7 @@ class LGEACClimate(LGEClimate):
         """Return the horizontal swing mode setting."""
         return self._api.state.horizontal_step_mode
 
+    @handle_api_errors
     async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
         """Set new target horizontal swing operation."""
         if swing_horizontal_mode not in (self.swing_horizontal_modes or []):
@@ -423,11 +429,13 @@ class LGEACClimate(LGEClimate):
             await self._device.set_horizontal_step_mode(swing_horizontal_mode)
             self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._device.power(True)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._device.power(False)
@@ -451,6 +459,7 @@ class LGEACClimate(LGEClimate):
             AWHP_MAX_TEMP if self._device.is_air_to_water else DEFAULT_MAX_TEMP
         )
 
+    @handle_api_errors
     async def async_set_sleep_time(self, sleep_time: int) -> None:
         """Call the set sleep time command for AC devices."""
         await self._device.set_reservation_sleep_time(sleep_time)
@@ -506,6 +515,7 @@ class LGERefrigeratorClimate(LGEClimate):
         except ValueError:
             return None
 
+    @handle_api_errors
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if (new_temp := kwargs.get(ATTR_TEMPERATURE)) is not None:

--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -1,8 +1,10 @@
 """Helper class for ThinQ devices"""
 
 from datetime import datetime, timedelta
+from functools import wraps
 
 from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.dt import utcnow
 
 from . import LGEDevice
@@ -25,6 +27,7 @@ from .const import (
     DEFAULT_SENSOR,
 )
 from .wideq import WM_DEVICE_TYPES, DeviceType, StateOptions, TemperatureUnit
+from .wideq.core_exceptions import APIError, ControlPermissionError
 
 STATE_LOOKUP = {
     StateOptions.OFF: STATE_OFF,
@@ -55,6 +58,35 @@ WASH_DEVICE_TYPES = [
     DeviceType.DISHWASHER,
     DeviceType.STYLER,
 ]
+
+
+def handle_api_errors(func):
+    """Report a failed device command as a failed service call.
+
+    Commands fail for reasons the user can act on: a V1 device whose control
+    permission is held by the ThinQ app, a device that is offline, a control
+    the model does not support. wideq signals all of these with APIError, and
+    left unhandled they surface as an internal error with a traceback instead
+    of the reason.
+    """
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except ControlPermissionError as exc:
+            # Refused because another client is driving the device right now,
+            # which makes this the moment our cached state is most likely to be
+            # wrong - it has been changing it without us seeing. Re-read before
+            # reporting, so a refused command does not also leave a stale value
+            # on screen until the next poll. The read does not need the
+            # permission, and the coordinator debounces the request.
+            await self.coordinator.async_request_refresh()
+            raise HomeAssistantError(str(exc)) from exc
+        except APIError as exc:
+            raise HomeAssistantError(str(exc)) from exc
+
+    return wrapper
 
 
 def get_entity_name(device: LGEDevice, ent_key: str) -> str | None:

--- a/custom_components/smartthinq_sensors/fan.py
+++ b/custom_components/smartthinq_sensors/fan.py
@@ -23,6 +23,7 @@ from homeassistant.util.percentage import (
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import handle_api_errors
 from .wideq import DeviceType, HoodFeatures, MicroWaveFeatures
 
 ATTR_FAN_MODE = "fan_mode"
@@ -341,6 +342,7 @@ class LGEFan(LGEBaseFan):
             return None
         return self._wrapper.fan_preset
 
+    @handle_api_errors
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         if self.speed_count == 0:
@@ -360,6 +362,7 @@ class LGEFan(LGEBaseFan):
             await self._wrapper.async_set_speed(named_speed)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if self.preset_modes is None:
@@ -370,6 +373,7 @@ class LGEFan(LGEBaseFan):
             await self._wrapper.async_set_preset(preset_mode)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -385,6 +389,7 @@ class LGEFan(LGEBaseFan):
             await self._wrapper.async_turn_on()
             self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
         if not self._wrapper.is_on:

--- a/custom_components/smartthinq_sensors/humidifier.py
+++ b/custom_components/smartthinq_sensors/humidifier.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import handle_api_errors
 from .wideq import DehumidifierFeatures, DeviceType
 from .wideq.devices.dehumidifier import DeHumidifierDevice
 
@@ -141,6 +142,7 @@ class LGEDeHumidifier(LGEBaseHumidifier):
             return self._api.state.fan_speed
         return self._api.state.operation_mode
 
+    @handle_api_errors
     async def async_set_mode(self, mode: str) -> None:
         """Set new target mode."""
         if not self.available_modes:
@@ -158,6 +160,7 @@ class LGEDeHumidifier(LGEBaseHumidifier):
         """Return the humidity we try to reach."""
         return self._api.state.device_features.get(DehumidifierFeatures.TARGET_HUMIDITY)
 
+    @handle_api_errors
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         humidity_step = self._device.target_humidity_step or 1
@@ -165,11 +168,13 @@ class LGEDeHumidifier(LGEBaseHumidifier):
         await self._device.set_target_humidity(target_humidity)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
         await self._device.power(True)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
         await self._device.power(False)
@@ -189,6 +194,7 @@ class LGEDeHumidifier(LGEBaseHumidifier):
             return max_value
         return DEFAULT_MAX_HUMIDITY
 
+    @handle_api_errors
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         if fan_mode not in self._device.fan_speeds:

--- a/custom_components/smartthinq_sensors/light.py
+++ b/custom_components/smartthinq_sensors/light.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import LGEBaseDevice
+from .device_helpers import LGEBaseDevice, handle_api_errors
 from .wideq import DeviceType, HoodFeatures, MicroWaveFeatures
 
 _LOGGER = logging.getLogger(__name__)
@@ -173,6 +173,7 @@ class LGELight(CoordinatorEntity, LightEntity):
             return self.effect is not None
         return self._api.state.is_on
 
+    @handle_api_errors
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         effect = kwargs.get(ATTR_EFFECT)
@@ -190,6 +191,7 @@ class LGELight(CoordinatorEntity, LightEntity):
             await self.entity_description.set_effect_fn(self._api, effect)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         if not self.is_on:

--- a/custom_components/smartthinq_sensors/select.py
+++ b/custom_components/smartthinq_sensors/select.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import handle_api_errors
 from .wideq import WM_DEVICE_TYPES, DeviceType, MicroWaveFeatures
 
 _LOGGER = logging.getLogger(__name__)
@@ -141,6 +142,7 @@ class LGESelect(CoordinatorEntity, SelectEntity):
         self._attr_device_info = api.device_info
         self._attr_options = self.entity_description.options_fn(self._api)
 
+    @handle_api_errors
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_option_fn(self._api, option)

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -53,6 +53,7 @@ from .device_helpers import (
     LGEBaseDevice,
     get_entity_name,
     get_wrapper_device,
+    handle_api_errors,
 )
 from .wideq import (
     SET_TIME_DEVICE_TYPES,
@@ -729,18 +730,21 @@ class LGESensor(CoordinatorEntity, SensorEntity):
 
         return None
 
+    @handle_api_errors
     async def async_remote_start(self, course: str | None = None):
         """Call the remote start command for WM devices."""
         if self._api.type not in WM_DEVICE_TYPES:
             raise NotImplementedError()
         await self._api.device.remote_start(course)
 
+    @handle_api_errors
     async def async_wake_up(self):
         """Call the wakeup command for WM devices."""
         if self._api.type not in WM_DEVICE_TYPES:
             raise NotImplementedError()
         await self._api.device.wake_up()
 
+    @handle_api_errors
     async def async_set_time(self, time_wanted: time | None = None):
         """Call the set time command for Microwave devices."""
         if self._api.type not in SET_TIME_DEVICE_TYPES:

--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import STATE_LOOKUP, LGEBaseDevice
+from .device_helpers import STATE_LOOKUP, LGEBaseDevice, handle_api_errors
 from .wideq import (
     WM_DEVICE_TYPES,
     AirConditionerFeatures,
@@ -261,6 +261,7 @@ class LGESwitch(LGEBaseSwitch):
             is_avail = self.entity_description.available_fn(self._wrap_device)
         return self._api.available and is_avail
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         if self.entity_description.turn_off_fn is None:
@@ -269,6 +270,7 @@ class LGESwitch(LGEBaseSwitch):
             await self.entity_description.turn_off_fn(self._wrap_device)
             self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         if self.entity_description.turn_on_fn is None:

--- a/custom_components/smartthinq_sensors/water_heater.py
+++ b/custom_components/smartthinq_sensors/water_heater.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import handle_api_errors
 from .wideq import (
     AirConditionerFeatures,
     DeviceType,
@@ -163,12 +164,14 @@ class LGEWHWaterHeater(LGEWaterHeater):
             return None
         return list(modes.values())
 
+    @handle_api_errors
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if new_temp := kwargs.get(ATTR_TEMPERATURE):
             await self._device.set_target_temp(int(new_temp))
             self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""
         modes = self._available_modes()
@@ -178,10 +181,12 @@ class LGEWHWaterHeater(LGEWaterHeater):
         await self._device.set_op_mode(new_mode)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the water heater on."""
         await self.async_set_operation_mode(STATE_HEAT_PUMP)
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the water heater off."""
         await self.async_set_operation_mode(STATE_OFF)
@@ -240,12 +245,14 @@ class LGEACWaterHeater(LGEWaterHeater):
             return STATE_HEAT_PUMP
         return STATE_OFF
 
+    @handle_api_errors
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         if new_temp := kwargs.get(ATTR_TEMPERATURE):
             await self._device.set_hot_water_target_temp(int(new_temp))
             self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""
         if operation_mode not in self.operation_list:
@@ -255,10 +262,12 @@ class LGEACWaterHeater(LGEWaterHeater):
         await self._device.hot_water_mode(operation_mode == STATE_HEAT_PUMP)
         self._api.async_set_updated()
 
+    @handle_api_errors
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the water heater on."""
         await self.async_set_operation_mode(STATE_HEAT_PUMP)
 
+    @handle_api_errors
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the water heater off."""
         await self.async_set_operation_mode(STATE_OFF)

--- a/custom_components/smartthinq_sensors/wideq/core_async.py
+++ b/custom_components/smartthinq_sensors/wideq/core_async.py
@@ -90,6 +90,12 @@ CLIENT_ID = "LGAO221A02"
 OAUTH_SECRET_KEY = "c053c2a6ddeb7ad97cb0eed0dcb31cf8"
 DATE_FORMAT = "%a, %d %b %Y %H:%M:%S +0000"
 
+# Errors specific to the V1 (THINQ1) API. Checked before API2_ERRORS, since
+# the two namespaces reuse code numbers for unrelated conditions.
+API1_ERRORS = {
+    "0011": exc.ControlPermissionError,
+}
+
 API2_ERRORS = {
     "0101": exc.DeviceNotFound,
     "0102": exc.NotLoggedInError,
@@ -446,6 +452,8 @@ class CoreAsync:
             code = msg["returnCd"]
             if code != "0000":
                 message = msg.get("returnMsg") or "ThinQ APIv1 error"
+                if code in API1_ERRORS:
+                    raise API1_ERRORS[code](message)
                 if code in API2_ERRORS:
                     raise API2_ERRORS[code](message)
                 raise exc.APIError(message, code)

--- a/custom_components/smartthinq_sensors/wideq/core_exceptions.py
+++ b/custom_components/smartthinq_sensors/wideq/core_exceptions.py
@@ -52,6 +52,32 @@ class DelayedResponseError(APIError):
     """The device delay in the response."""
 
 
+class ControlPermissionError(APIError):
+    """Another client holds the control permission for this V1 device.
+
+    V1 (THINQ1) devices grant control to a single client at a time. The LG
+    ThinQ app acquires the permission when its device page is opened and
+    releases it on exit; a client that quits without releasing leaves the
+    device locked. The server reports this as code 0011, whose generic
+    returnMsg is misleading - the app itself renders it as "<device> is in
+    use, please wait".
+
+    rti/delControlPermission only releases a permission held by the calling
+    session, so a lock held by another client cannot be broken remotely - it
+    has to be released by whoever holds it.
+    """
+
+    def __init__(self, message="", code=None):
+        self.server_message = message
+        text = (
+            "Device is being controlled by another app - close the LG ThinQ app"
+            " (back out of the device page) and try again"
+        )
+        if message:
+            text = f"{text}. Server reported: {message}"
+        super().__init__(text, code)
+
+
 class UseOfficialAPIError(APIError):
     """Requests stop responding suggesting to move to official public API."""
 

--- a/custom_components/smartthinq_sensors/wideq/device.py
+++ b/custom_components/smartthinq_sensors/wideq/device.py
@@ -49,6 +49,11 @@ LOCAL_LANG_PACK = {
 }
 
 MIN_TIME_BETWEEN_CLI_REFRESH = 10  # seconds
+# Backstop for a V1 control permission that could not be handed back straight
+# after a command: the first poll this long afterwards releases it. While it is
+# held, the ThinQ app reports the device as controlled elsewhere, so the normal
+# path releases immediately rather than waiting for this.
+CONTROL_PERMISSION_GRACE = 60  # seconds
 MAX_RETRIES = 3
 MAX_UPDATE_FAIL_ALLOWED = 10
 MAX_INVALID_CREDENTIAL_ERR = 3
@@ -416,6 +421,7 @@ class Device:
         self._should_poll = device_info.platform_type == PlatformType.THINQ1
         self._mon = Monitor(client, device_info)
         self._control_set = 0
+        self._control_set_time: datetime | None = None
         self._last_additional_poll: datetime | None = None
         self._available_features = {}
 
@@ -553,14 +559,58 @@ class Device:
             return
 
         if self._should_poll:
-            await self._client.session.set_device_controls(
-                self._device_info.device_id,
-                ctrl_key,
-                command,
-                {key: value} if key and value else value,
-                {key: data} if key and data else data,
-            )
+            device_id = self._device_info.device_id
+            ctrl_value = {key: value} if key and value else value
+            ctrl_data = {key: data} if key and data else data
+            held_permission = self._control_set > 0
+            # Assume the permission is taken the moment a command is issued, so
+            # that a command failing part way through still schedules a release
+            # rather than leaking the lock.
             self._control_set = 2
+            self._control_set_time = datetime.now(timezone.utc)
+            try:
+                await self._client.session.set_device_controls(
+                    device_id, ctrl_key, command, ctrl_value, ctrl_data
+                )
+            except core_exc.ControlPermissionError:
+                # Refused, so no permission was taken.
+                self._control_set = 0
+                self._control_set_time = None
+                # delControlPermission only releases a permission held by this
+                # session. Retrying is worth it when we were holding one, since
+                # it may be stale; when we were not, the holder is another
+                # client and only it can release, so fail without spending a
+                # further call on an API that rate limits hard.
+                if not held_permission:
+                    raise
+                _LOGGER.debug(
+                    "Device %s refused control, dropping our permission and retrying",
+                    device_id,
+                )
+                await self._client.session.delete_permission(device_id)
+                await self._client.session.set_device_controls(
+                    device_id, ctrl_key, command, ctrl_value, ctrl_data
+                )
+                self._control_set = 2
+                self._control_set_time = datetime.now(timezone.utc)
+            except core_exc.DelayedResponseError:
+                # "제품 응답 지연" - the device did not answer in time. Seen when
+                # another client is mid-session with it, and it clears on a
+                # second attempt. Not a permission problem: the app shows this
+                # one without releasing anything, so neither do we. Commands are
+                # absolute value sets, so repeating one is harmless.
+                _LOGGER.debug(
+                    "Device %s did not answer command in time, retrying", device_id
+                )
+                await asyncio.sleep(SLEEP_BETWEEN_RETRIES)
+                await self._client.session.set_device_controls(
+                    device_id, ctrl_key, command, ctrl_value, ctrl_data
+                )
+            # Hand the permission straight back. Holding it gains nothing - the
+            # next command reacquires it implicitly - and for as long as we do,
+            # the ThinQ app tells the user the device is controlled elsewhere.
+            # If this fails, the grace period below is the backstop.
+            await self.release_control_permission()
             return
 
         await self._client.session.device_v2_controls(
@@ -666,9 +716,37 @@ class Device:
             return
         if self._control_set <= 0:
             return
-        if self._control_set == 1:
+        if self._control_set_time is not None:
+            elapsed = (
+                datetime.now(timezone.utc) - self._control_set_time
+            ).total_seconds()
+            if elapsed < CONTROL_PERMISSION_GRACE:
+                return
+        await self._client.session.delete_permission(self._device_info.device_id)
+        self._control_set = 0
+        self._control_set_time = None
+
+    async def release_control_permission(self):
+        """Release a held V1 control permission, ignoring the grace period.
+
+        Called on shutdown: a permission left behind when Home Assistant stops
+        is not recoverable afterwards, since the next session cannot release
+        another session's lock. It would block both the ThinQ app and our own
+        next start until the server expires it.
+        """
+        if not self._should_poll or self._control_set <= 0:
+            return
+        try:
             await self._client.session.delete_permission(self._device_info.device_id)
-        self._control_set -= 1
+        except Exception:  # pylint: disable=broad-except
+            # Shutting down must not fail because of a best-effort release.
+            _LOGGER.debug(
+                "Failed to release control permission for device %s",
+                self._device_info.device_id,
+                exc_info=True,
+            )
+        self._control_set = 0
+        self._control_set_time = None
 
     async def _pre_update_v2(self):
         """


### PR DESCRIPTION
Fixes the `0011 - 등록되지 않은 모델입니다` failures reported in #964 (closed as stale, but still reproducible and reported by more than one user).

## What is actually happening

V1 (THINQ1) devices grant control to **one client at a time**. Sending `rti/rtiControl` implicitly takes that permission, and `rti/delControlPermission` releases it. While a client holds it, every other client is refused with code `0011`.

The server's `returnMsg` for `0011` is misleading — it translates to "unregistered model", which sends people looking for a device support problem. LG's own per-device app module maps this same code to `@CP_UX30_USE_PRODUCT_WAIT`, which the app renders as "&lt;device&gt; is in use". So it is a lock, not a model issue.

Two consequences, both of which users hit:

1. **The ThinQ app locks Home Assistant out.** The app takes the permission when its device page is opened and releases it on exit. An app left sitting on that page — or killed there — blocks every write from this integration. Reads keep working, so the device looks online and only commands fail, which matches the intermittent "sometimes I cannot set the temperature" in #964.

2. **Home Assistant locks the ThinQ app out.** This is the part I did not expect. The permission taken by a command was only released on the *next* poll, so after every command we held it for up to a full poll interval, and the app told the user the device was being controlled elsewhere for that entire time. Config reads (`get_power`, `get_filter_state`) go over `rti/rtiControl` too, so they take it as well.

`rti/delControlPermission` only releases a permission held by the **calling session** — verified empirically: retrying after `delControlPermission` against a lock held by the phone app fails identically. So a lock held by another client genuinely cannot be broken remotely; it has to be released by whoever holds it, or expire.

## Changes

**`0011` becomes a named exception with an actionable message.** A new `API1_ERRORS` table is checked before `API2_ERRORS`, since the two namespaces reuse code numbers for unrelated conditions. `ControlPermissionError` carries the server's original text as a secondary detail so the reported string is still greppable.

**The permission is handed back immediately after every command**, instead of at the next poll. Holding it gains nothing — the next command reacquires it implicitly — and for as long as we hold it the app reports the device as controlled elsewhere. A time-based grace period (`CONTROL_PERMISSION_GRACE`) remains as the backstop for a release that itself failed.

**A refused command retries only when we were already holding a permission**, since that one may be stale and is ours to drop. When we were not holding one, the holder is another client, so retrying cannot help; it fails fast rather than spending another call on an API that rate limits hard.

**`0111` (`제품 응답 지연`, "product response delay") retries once.** The app shows this one without releasing anything, so neither do we. Commands are absolute value sets, so repeating one is harmless.

**The permission is released on unload.** One left behind when Home Assistant stops is not recoverable afterwards — the next session cannot release another session's lock — and would block both the app and our own next start until the server expires it.

**Failed commands are reported as failed service calls.** `APIError` propagated out of the entity methods untouched, so Home Assistant treated a busy or offline device as a crash in the integration: `unknown_error` on the websocket and a full traceback in the log — exactly the "Unexpected exception" traceback in #964. A `handle_api_errors` decorator on the entity command methods translates `APIError` into `HomeAssistantError`. Non-API exceptions are deliberately left alone, since those are bugs and should still surface as such.

## Testing

Tested against a real THINQ1 unit (`PAC_910604_KR`), with the ThinQ app used to take and release the lock.

With the app holding the permission, the frontend now receives:

```json
{
  "success": false,
  "error": {
    "code": "home_assistant_error",
    "message": "Device is being controlled by another app - close the LG ThinQ app (back out of the device page) and try again. Server reported: 등록되지 않은 모델입니다."
  }
}
```

instead of `unknown_error` plus a traceback. With the app backed out, commands succeed, and the app no longer reports the device as controlled elsewhere after a Home Assistant command.

I only have a V1 air conditioner to test on, so the wideq changes are exercised on that path; the decorator is applied across all the entity command platforms.