### PR TITLE
Raise NotImplementedError in the fan preset guard instead of returning it

### DIFF
--- a/custom_components/smartthinq_sensors/fan.py
+++ b/custom_components/smartthinq_sensors/fan.py
@@ -237,7 +237,7 @@ class LGEFanWrapper:
     async def async_set_preset(self, preset: str) -> None:
         """Set fan preset."""
         if self._description.set_fanpreset_fn is None:
-            return NotImplementedError()
+            raise NotImplementedError()
         await self._description.set_fanpreset_fn(self._api, preset)
 
     async def async_turn_on(


### PR DESCRIPTION
`LGEFanWrapper.async_set_preset` builds the exception and returns it:

```python
async def async_set_preset(self, preset: str) -> None:
    """Set fan preset."""
    if self._description.set_fanpreset_fn is None:
        return NotImplementedError()
    await self._description.set_fanpreset_fn(self._api, preset)
```

so a missing `set_fanpreset_fn` silently does nothing instead of signalling that the control is unsupported. The caller discards the return value. The two sibling guards in this same file (`async_set_percentage`, `async_set_preset_mode`) both `raise`.

**No behaviour change today.** None of the four wrapper descriptions defines `fanpresets_fn` without also defining `set_fanpreset_fn`, so `_attr_preset_modes` is only set when the setter exists. `preset_modes` is therefore `None` whenever the setter is missing, and `LGEFan.async_set_preset_mode` already raises before the wrapper is reached. This just keeps the guard correct if that ever stops holding.

Split out of #988 as an unrelated one-line fix.