### PR TITLE
Create entities for features a device only reports after setup

### DIFF
--- a/custom_components/smartthinq_sensors/__init__.py
+++ b/custom_components/smartthinq_sensors/__init__.py
@@ -415,6 +415,9 @@ class LGEDevice:
         self._coordinator: DataUpdateCoordinator | None = None
         self._disc_count = 0
         self._available = True
+        # None until setup has finished, so the polls that run during setup do
+        # not report every feature the device has as a late arrival.
+        self._known_features: set[str] | None = None
 
     @property
     def available(self) -> bool:
@@ -496,6 +499,7 @@ class LGEDevice:
 
         # Initialize device features
         _ = self._state.device_features
+        self._known_features = set(self._device.available_features)
 
         return True
 
@@ -577,6 +581,42 @@ class LGEDevice:
             # _LOGGER.debug('Status attributes: %s', l)
             self._disc_count = 0
             self._state = state
+            self._async_discover_late_features()
+
+    @callback
+    def _async_discover_late_features(self) -> None:
+        """Set up entities for features the device only reported later.
+
+        A feature is only known once the appliance has reported a value for
+        it, so the set we have at startup is whatever that first poll
+        happened to return. A poll that comes back empty, or one whose
+        config reads are refused because the ThinQ app holds the V1 control
+        permission, leaves features missing - and every entity gated on one
+        is then never created, with nothing in the log to say so. They stay
+        missing until the next reload, however healthy later polls are.
+
+        So re-run discovery whenever the set grows and let the platforms pick
+        up what is now known. Entities that already exist are filtered out by
+        their unique_id, so this is a no-op once the device has settled.
+        """
+        if self._known_features is None:
+            # Still inside init_device: no platform is listening yet, and the
+            # features found here are the baseline rather than late arrivals.
+            return
+
+        _ = self._state.device_features
+        features = set(self._device.available_features)
+        if not (new_features := features - self._known_features):
+            return
+
+        self._known_features = features
+        _LOGGER.debug(
+            "Device %s reported %d new feature(s) after setup: %s",
+            self._name,
+            len(new_features),
+            ", ".join(sorted(new_features)),
+        )
+        async_dispatcher_send(self._hass, LGE_DISCOVERY_NEW, {self._type: [self]})
 
 
 async def lge_devices_setup(

--- a/custom_components/smartthinq_sensors/binary_sensor.py
+++ b/custom_components/smartthinq_sensors/binary_sensor.py
@@ -34,6 +34,7 @@ from .device_helpers import (
     STATE_LOOKUP,
     WASH_DEVICE_TYPES,
     LGEBaseDevice,
+    entity_adder,
     get_entity_name,
     get_wrapper_device,
 )
@@ -226,6 +227,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE binary sensors."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -248,7 +250,7 @@ async def async_setup_entry(
             if _binary_sensor_exist(lge_device, sensor_desc)
         ]
 
-        async_add_entities(lge_sensors)
+        add_entities(lge_sensors)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/button.py
+++ b/custom_components/smartthinq_sensors/button.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import LGEBaseDevice
+from .device_helpers import LGEBaseDevice, entity_adder
 from .wideq import WM_DEVICE_TYPES, WashDeviceFeatures
 
 # general button attributes
@@ -87,6 +87,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE buttons."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -107,7 +108,7 @@ async def async_setup_entry(
             if _button_exist(lge_device, button_desc)
         ]
 
-        async_add_entities(lge_button)
+        add_entities(lge_button)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/climate.py
+++ b/custom_components/smartthinq_sensors/climate.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import TEMP_UNIT_LOOKUP, LGERefrigeratorDevice
+from .device_helpers import TEMP_UNIT_LOOKUP, LGERefrigeratorDevice, entity_adder
 from .wideq import AirConditionerFeatures, DeviceType, TemperatureUnit
 from .wideq.devices.ac import (
     AWHP_MAX_TEMP,
@@ -129,6 +129,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up LGE device climate based on config_entry."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -156,7 +157,7 @@ async def async_setup_entry(
             ]
         )
 
-        async_add_entities(lge_climates)
+        add_entities(lge_climates)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/device_helpers.py
+++ b/custom_components/smartthinq_sensors/device_helpers.py
@@ -1,8 +1,12 @@
 """Helper class for ThinQ devices"""
 
+from collections.abc import Callable, Iterable
 from datetime import datetime, timedelta
 
 from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
 from . import LGEDevice
@@ -55,6 +59,29 @@ WASH_DEVICE_TYPES = [
     DeviceType.DISHWASHER,
     DeviceType.STYLER,
 ]
+
+
+def entity_adder(
+    async_add_entities: AddEntitiesCallback,
+) -> Callable[[Iterable[Entity]], None]:
+    """Wrap async_add_entities so a repeated discovery only adds what is new.
+
+    Discovery runs again for a device we have already set up when it reports
+    features it did not report at startup, so the platform rebuilds every
+    entity for that device. Filtering on unique_id lets the new ones through
+    and drops the rest, instead of adding duplicates.
+    """
+    added: set[str] = set()
+
+    @callback
+    def _async_add_new_entities(entities: Iterable[Entity]) -> None:
+        new_entities = [ent for ent in entities if ent.unique_id not in added]
+        if not new_entities:
+            return
+        added.update(ent.unique_id for ent in new_entities)
+        async_add_entities(new_entities)
+
+    return _async_add_new_entities
 
 
 def get_entity_name(device: LGEDevice, ent_key: str) -> str | None:

--- a/custom_components/smartthinq_sensors/fan.py
+++ b/custom_components/smartthinq_sensors/fan.py
@@ -23,6 +23,7 @@ from homeassistant.util.percentage import (
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import entity_adder
 from .wideq import DeviceType, HoodFeatures, MicroWaveFeatures
 
 ATTR_FAN_MODE = "fan_mode"
@@ -141,6 +142,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up LGE device fan based on config_entry."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -162,7 +164,7 @@ async def async_setup_entry(
             if _fan_exist(lge_device, fan_desc)
         ]
 
-        async_add_entities(lge_fan)
+        add_entities(lge_fan)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/humidifier.py
+++ b/custom_components/smartthinq_sensors/humidifier.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import entity_adder
 from .wideq import DehumidifierFeatures, DeviceType
 from .wideq.devices.dehumidifier import DeHumidifierDevice
 
@@ -36,6 +37,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up LGE device humidifier based on config_entry."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -54,7 +56,7 @@ async def async_setup_entry(
             for lge_device in lge_devices.get(DeviceType.DEHUMIDIFIER, [])
         ]
 
-        async_add_entities(lge_humidifier)
+        add_entities(lge_humidifier)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/light.py
+++ b/custom_components/smartthinq_sensors/light.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import LGEBaseDevice
+from .device_helpers import LGEBaseDevice, entity_adder
 from .wideq import DeviceType, HoodFeatures, MicroWaveFeatures
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,6 +79,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE selects."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -99,7 +100,7 @@ async def async_setup_entry(
             if _light_exist(lge_device, light_desc)
         ]
 
-        async_add_entities(lge_light)
+        add_entities(lge_light)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/select.py
+++ b/custom_components/smartthinq_sensors/select.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import entity_adder
 from .wideq import WM_DEVICE_TYPES, DeviceType, MicroWaveFeatures
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,6 +94,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE selects."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -113,7 +115,7 @@ async def async_setup_entry(
             if _select_exist(lge_device, select_desc)
         ]
 
-        async_add_entities(lge_select)
+        add_entities(lge_select)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/sensor.py
+++ b/custom_components/smartthinq_sensors/sensor.py
@@ -51,6 +51,7 @@ from .device_helpers import (
     DEVICE_ICONS,
     WASH_DEVICE_TYPES,
     LGEBaseDevice,
+    entity_adder,
     get_entity_name,
     get_wrapper_device,
 )
@@ -578,6 +579,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE sensors."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -605,7 +607,7 @@ async def async_setup_entry(
             for lge_device in lge_devices.get(dev_type, [])
         ]
 
-        async_add_entities(lge_sensors + lge_common_sensors)
+        add_entities(lge_sensors + lge_common_sensors)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/switch.py
+++ b/custom_components/smartthinq_sensors/switch.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
-from .device_helpers import STATE_LOOKUP, LGEBaseDevice
+from .device_helpers import STATE_LOOKUP, LGEBaseDevice, entity_adder
 from .wideq import (
     WM_DEVICE_TYPES,
     AirConditionerFeatures,
@@ -168,6 +168,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the LGE switch."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -197,7 +198,7 @@ async def async_setup_entry(
             ]
         )
 
-        async_add_entities(lge_switch)
+        add_entities(lge_switch)
 
     _async_discover_device(lge_cfg_devices)
 

--- a/custom_components/smartthinq_sensors/water_heater.py
+++ b/custom_components/smartthinq_sensors/water_heater.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LGEDevice
 from .const import DOMAIN, LGE_DEVICES, LGE_DISCOVERY_NEW
+from .device_helpers import entity_adder
 from .wideq import (
     AirConditionerFeatures,
     DeviceType,
@@ -55,6 +56,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up LGE device water heater based on config_entry."""
+    add_entities = entity_adder(async_add_entities)
     entry_config = hass.data[DOMAIN]
     lge_cfg_devices = entry_config.get(LGE_DEVICES)
 
@@ -82,7 +84,7 @@ async def async_setup_entry(
             ]
         )
 
-        async_add_entities(lge_water_heater)
+        add_entities(lge_water_heater)
 
     _async_discover_device(lge_cfg_devices)
 


### PR DESCRIPTION
A feature only becomes known once the appliance has reported a value for
it, so the feature set a device ends setup with is whatever its first poll
happened to return. `available_features` keeps growing as later polls bring
new values in, but the platforms only ever run discovery once, so anything
learned after setup never gets an entity.

That first poll is not reliable:

* it can come back empty, and the device is then set up with almost no
  features at all;
* its `_additional_poll` config reads can be refused while another client
  holds the device, which on a V1 appliance is any moment the ThinQ app has
  it open;
* an appliance that is simply off does not report the values behind its
  own controls.

Nothing logs any of this, and no amount of healthy polling afterwards
brings the entities back - only a reload does. On a V1 air conditioner
that was restarted while the ThinQ app was open, this silently dropped the
energy, filter, room temperature, sleep time, diagnosis and four mode
switch entities for the rest of the session; they stayed `unavailable` in
the registry with nothing behind them.

So re-run discovery when a device reports features it did not have before,
and have the platforms drop entities whose unique_id they have already
added, which makes the extra runs free once a device has settled. Polls
during `init_device` are skipped so a device's startup features are not
reported as late arrivals.

Verified on a live install: after a restart, a refrigerator reported
`active_saving_status`, `fresh_air_filter`, `ice_plus`, `locking_status`
and `smart_saving_mode_status` on the poll following setup, and the three
entities gated on them were created at that moment instead of being lost
until the next reload. No duplicate unique_id warnings across restarts,
reloads and repeated discovery.