### PR TITLE
Report 0 W while the unit is off, and no setpoint in fan-only

### DIFF
--- a/custom_components/smartthinq_sensors/climate.py
+++ b/custom_components/smartthinq_sensors/climate.py
@@ -254,9 +254,25 @@ class LGEACClimate(LGEClimate):
         return self._preset_mode_lookup
 
     @property
+    def _is_fan_only(self) -> bool:
+        """Return whether the unit is set to fan-only, on or off.
+
+        Fan-only just moves air, so there is nothing to reach, but the unit
+        keeps reporting the setpoint it last cooled to. Read the mode the unit
+        holds rather than the hvac mode, which is only ever OFF while the unit
+        is off and so would let the stale setpoint back in.
+        """
+        op_mode: str | None = self._api.state.operation_mode
+        if op_mode is None:
+            return False
+        return self._available_hvac_modes().get(op_mode) == HVACMode.FAN_ONLY
+
+    @property
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = DEFAULT_AC_FEATURES
+        if self._is_fan_only:
+            features &= ~ClimateEntityFeature.TARGET_TEMPERATURE
         if len(self.fan_modes) > 0:
             features |= ClimateEntityFeature.FAN_MODE
         if self.preset_modes:
@@ -359,8 +375,10 @@ class LGEACClimate(LGEClimate):
         return self._api.state.device_features.get(AirConditionerFeatures.HUMIDITY)
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
+        if self._is_fan_only:
+            return None
         return self._api.state.target_temp
 
     async def async_set_temperature(self, **kwargs) -> None:

--- a/custom_components/smartthinq_sensors/wideq/devices/ac.py
+++ b/custom_components/smartthinq_sensors/wideq/devices/ac.py
@@ -819,6 +819,7 @@ class AirConditionerDevice(Device):
             return None
         try:
             value = await self._get_config(STATE_POWER_V1)
+            _LOGGER.debug("Device %s instant power: %s W", self.name, value)
             return value[STATE_POWER_V1]
         except (ValueError, InvalidRequestError) as exc:
             # Device does not support whole unit instant power usage
@@ -1158,9 +1159,13 @@ class AirConditionerStatus(DeviceStatus):
         key = self._get_state_key(STATE_POWER)
         if (value := self.to_int_or_none(self._data.get(key))) is None:
             return None
-        if value <= 50 and not self.is_on:
-            # decrease power for devices that always return 50 when standby
-            value = 5
+        if not self.is_on:
+            # A unit that is off draws nothing, but it keeps reporting the last
+            # power it measured while running - the fan speed it was on as it
+            # was switched off, say - and reports it unchanged for as long as
+            # it stays off. Nothing about that reading is current, so report
+            # the only figure that is true of a unit that is off.
+            value = 0
         return self._update_feature(AirConditionerFeatures.ENERGY_CURRENT, value, False)
 
     @property


### PR DESCRIPTION
## Problem

Two issues with how the climate entity reports state:

1. **Stale power reading when off.** An AC that is off keeps reporting the last power it measured while running. The value depends on the mode before shutoff — fan-high leaves 53 W, fan-low leaves 32 W, a compressor run leaves hundreds. The existing code tried to handle this with `if value <= 50 and not self.is_on: value = 5`, but that only caught some cases and still left a phantom 5 W reading.

2. **Target temperature shown in fan-only mode.** Fan-only just moves air — there is no setpoint to reach. But the entity kept showing the setpoint last used for cooling (e.g. 18 °C), even when the unit was off in fan mode.

## Fix

**Power:** replace the threshold with a flat `if not self.is_on: value = 0`. An off unit draws nothing.

**Fan-only setpoint:** add an `_is_fan_only` property that reads the operation mode the unit actually holds, not the HA hvac_mode (which collapses to OFF when the unit is off and would let the stale setpoint back in). When fan-only:
- Clear `TARGET_TEMPERATURE` from `supported_features` so the UI drops the temperature control
- Return `None` from `target_temperature` so the attribute is absent

Also adds a debug log line in `get_power()` for diagnosing V1 power reporting.